### PR TITLE
Prefix stderr output with "Verlite:"

### DIFF
--- a/src/Verlite.CLI/ConsoleLogger.cs
+++ b/src/Verlite.CLI/ConsoleLogger.cs
@@ -6,20 +6,24 @@ namespace Verlite.CLI
 	{
 		public Verbosity Verbosity { get; set; }
 
+		// It's important we prefix all newlines with "Verlite:", as MsBuild uses it to ignore output
+		private static string SanitizeMessage(string message)
+			=> $"Verlite: {message.Replace("\n", "\nVerlite: ", StringComparison.Ordinal)}";
+
 		void ILogger.Normal(string message)
 		{
 			if (Verbosity >= Verbosity.normal)
-				Console.Error.WriteLine(message);
+				Console.Error.WriteLine($"Verlite: {SanitizeMessage(message)}");
 		}
 		void ILogger.Verbose(string message)
 		{
 			if (Verbosity >= Verbosity.verbose)
-				Console.Error.WriteLine(message);
+				Console.Error.WriteLine($"Verlite: {SanitizeMessage(message)}");
 		}
 		void ILogger.Verbatim(string message)
 		{
 			if (Verbosity >= Verbosity.verbatim)
-				Console.Error.WriteLine(message);
+				Console.Error.WriteLine($"Verlite: {SanitizeMessage(message)}");
 		}
 	}
 }


### PR DESCRIPTION
Standard error is captured and filtered out in Verlite.MsBuild.targets (derived from MinVer's). Without this prefix, the output would be incorrectly included as part of the version.

Found via the MsBuild integration tests.