### PR TITLE
Updates to GitHub Actions

### DIFF
--- a/.github/continuous-delivery.yml
+++ b/.github/continuous-delivery.yml
@@ -16,13 +16,11 @@ defaults: *default-defaults
 
 jobs:
   build-and-test:
-    name: Build & Test
+    name: 'Build & Test'
     runs-on: ubuntu-latest
     steps:
     - *checkout
     - *setup-dotnet5
-    - *setup-nuget
-    - *setup-nuget-cache
     - *restore
     - *build
     - *test
@@ -30,21 +28,20 @@ jobs:
     - *publish-codecov
     - *upload-artifacts
   integration-tests:
-    name: Integration Tests
+    name: 'Integration Tests'
     needs: build-and-test
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
     - *checkout
     - *setup-dotnet5
     - *setup-dotnet3-1
-    - *setup-nuget
-    - *setup-nuget-cache
     - *run-integration-tests
   publish:
-    name: Publish
+    name: 'Publish'
     needs: integration-tests
     runs-on: ubuntu-latest
     steps:

--- a/.github/continuous-integration.yml
+++ b/.github/continuous-integration.yml
@@ -16,13 +16,11 @@ defaults: *default-defaults
 
 jobs:
   build-and-test:
-    name: Build & Test
+    name: 'Build & Test'
     runs-on: ubuntu-latest
     steps:
     - *checkout
     - *setup-dotnet5
-    - *setup-nuget
-    - *setup-nuget-cache
     - *restore
     - *build
     - *test
@@ -30,7 +28,7 @@ jobs:
     - *publish-codecov
     - *upload-artifacts
   integration-tests:
-    name: Integration Tests
+    name: 'Integration Tests'
     needs: build-and-test
     runs-on: ${{ matrix.os }}
     strategy:
@@ -41,6 +39,4 @@ jobs:
     - *checkout
     - *setup-dotnet5
     - *setup-dotnet3-1
-    - *setup-nuget
-    - *setup-nuget-cache
     - *run-integration-tests

--- a/.github/deploy-release.yml
+++ b/.github/deploy-release.yml
@@ -9,18 +9,18 @@ defaults: *default-defaults
 
 jobs:
   build:
+    name: 'Build & Release'
     runs-on: ubuntu-latest
     steps:
     - *checkout
     - *setup-dotnet5
     - *setup-nuget
-    - *setup-nuget-cache
 
     - name: Setup MinVer for release
       run: |
         git fetch --tags --force
         git checkout "${GITHUB_REF#refs/*/}"
-        dotnet tool install --global minver-cli --version 2.4.0
+        dotnet tool install --global minver-cli --version 2.5.0
         curl https://github.com/AshleighAdams.gpg | gpg --import
 
     - *restore
@@ -29,7 +29,7 @@ jobs:
     - *pack
     - *upload-artifacts
 
-    - name: Create Release
+    - name: 'Create Release'
       run: |
         set -x
         tag="${GITHUB_REF#refs/*/}"
@@ -53,7 +53,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Publish Nuget
+    - name: 'Publish Nuget'
       run: |
         dotnet nuget push 'artifacts/*.nupkg' -k ${NUGETORG_TOKEN} -s https://api.nuget.org/v3/index.json --skip-duplicate --no-symbols 1
         dotnet nuget push 'artifacts/*.nupkg' -k ${GITHUB_TOKEN} -s github --skip-duplicate --no-symbols 1

--- a/.github/shared.yml
+++ b/.github/shared.yml
@@ -28,16 +28,6 @@ definitions:
       dotnet nuget update source github --store-password-in-clear-text --username AshleighAdams --password ${{ secrets.PERSONAL_ACCESS_TOKEN }}
       dotnet nuget enable source github
 
-  setup-nuget-cache: &setup-nuget-cache
-    name: NuGet Restore Cache
-    uses: actions/cache@v2
-    with:
-      path: ~/.nuget/packages
-      key: |
-        ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Build.props') }}-${{ hashFiles('**/*.csproj') }}
-      restore-keys: |
-        ${{ runner.os }}-nuget-
-
   restore: &restore
     name: Restore
     run: dotnet restore

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -33,20 +33,6 @@ jobs:
       with:
         dotnet-version: 5.0.x
 
-    - name: Setup NuGet
-      run: |
-        dotnet nuget update source github --store-password-in-clear-text --username AshleighAdams --password ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        dotnet nuget enable source github
-
-    - name: NuGet Restore Cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.nuget/packages
-        key: |
-          ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Build.props') }}-${{ hashFiles('**/*.csproj') }}
-        restore-keys: |
-          ${{ runner.os }}-nuget-
-
     - name: Restore
       run: dotnet restore
 
@@ -78,6 +64,7 @@ jobs:
     needs: build-and-test
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
@@ -94,20 +81,6 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x
-
-    - name: Setup NuGet
-      run: |
-        dotnet nuget update source github --store-password-in-clear-text --username AshleighAdams --password ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        dotnet nuget enable source github
-
-    - name: NuGet Restore Cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.nuget/packages
-        key: |
-          ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Build.props') }}-${{ hashFiles('**/*.csproj') }}
-        restore-keys: |
-          ${{ runner.os }}-nuget-
 
     - name: Run Integration Tests
       run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -33,20 +33,6 @@ jobs:
       with:
         dotnet-version: 5.0.x
 
-    - name: Setup NuGet
-      run: |
-        dotnet nuget update source github --store-password-in-clear-text --username AshleighAdams --password ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        dotnet nuget enable source github
-
-    - name: NuGet Restore Cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.nuget/packages
-        key: |
-          ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Build.props') }}-${{ hashFiles('**/*.csproj') }}
-        restore-keys: |
-          ${{ runner.os }}-nuget-
-
     - name: Restore
       run: dotnet restore
 
@@ -95,20 +81,6 @@ jobs:
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: 3.1.x
-
-    - name: Setup NuGet
-      run: |
-        dotnet nuget update source github --store-password-in-clear-text --username AshleighAdams --password ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-        dotnet nuget enable source github
-
-    - name: NuGet Restore Cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.nuget/packages
-        key: |
-          ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Build.props') }}-${{ hashFiles('**/*.csproj') }}
-        restore-keys: |
-          ${{ runner.os }}-nuget-
 
     - name: Run Integration Tests
       run: |

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -14,6 +14,7 @@ defaults:
 
 jobs:
   build:
+    name: Build & Release
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -30,21 +31,12 @@ jobs:
         dotnet nuget update source github --store-password-in-clear-text --username AshleighAdams --password ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         dotnet nuget enable source github
 
-    - name: NuGet Restore Cache
-      uses: actions/cache@v2
-      with:
-        path: ~/.nuget/packages
-        key: |
-          ${{ runner.os }}-nuget-${{ hashFiles('**/Directory.Build.props') }}-${{ hashFiles('**/*.csproj') }}
-        restore-keys: |
-          ${{ runner.os }}-nuget-
-
 
     - name: Setup MinVer for release
       run: |
         git fetch --tags --force
         git checkout "${GITHUB_REF#refs/*/}"
-        dotnet tool install --global minver-cli --version 2.4.0
+        dotnet tool install --global minver-cli --version 2.5.0
         curl https://github.com/AshleighAdams.gpg | gpg --import
 
     - name: Restore


### PR DESCRIPTION
- Removed the NuGet cache, as it was overall slower.
- Disable the need for GitHub Registry secrets, so forks can run CI workflows.
- Updated MinVer to match the version in the project files.