### PR TITLE
Verlite.Core: Fix MinimumVersion typo.

### DIFF
--- a/src/Verlite.CLI/Program.cs
+++ b/src/Verlite.CLI/Program.cs
@@ -121,7 +121,7 @@ namespace Verlite.CLI
 				{
 					TagPrefix = tagPrefix,
 					DefaultPrereleasePhase = defaultPrereleasePhase,
-					MinimiumVersion = minVersion,
+					MinimumVersion = minVersion,
 					PrereleaseBaseHeight = prereleaseBaseHeight,
 					VersionOverride = versionOverride,
 					BuildMetadata = buildMetadata,

--- a/src/Verlite.CLI/VersionParsers.cs
+++ b/src/Verlite.CLI/VersionParsers.cs
@@ -8,13 +8,13 @@ namespace Verlite.CLI
 		public static SemVer ParseMinSemVer(System.CommandLine.Parsing.ArgumentResult result)
 		{
 			if (result.Tokens.Count == 0)
-				return Program.DefaultOptions.MinimiumVersion;
+				return Program.DefaultOptions.MinimumVersion;
 
 			var tokenValue = result.Tokens.Single().Value;
 			if (!SemVer.TryParse(tokenValue, out var version))
 			{
 				result.ErrorMessage = $"Failed to parse version {tokenValue} for option {result.Argument.Name}";
-				return Program.DefaultOptions.MinimiumVersion;
+				return Program.DefaultOptions.MinimumVersion;
 			}
 
 			return version.Value;

--- a/src/Verlite.Core/PublicAPI.Shipped.txt
+++ b/src/Verlite.Core/PublicAPI.Shipped.txt
@@ -137,6 +137,8 @@ Verlite.VersionCalculationOptions.DefaultPrereleasePhase.get -> string!
 Verlite.VersionCalculationOptions.DefaultPrereleasePhase.set -> void
 Verlite.VersionCalculationOptions.MinimiumVersion.get -> Verlite.SemVer
 Verlite.VersionCalculationOptions.MinimiumVersion.set -> void
+Verlite.VersionCalculationOptions.MinimumVersion.get -> Verlite.SemVer
+Verlite.VersionCalculationOptions.MinimumVersion.set -> void
 Verlite.VersionCalculationOptions.PrereleaseBaseHeight.get -> int
 Verlite.VersionCalculationOptions.PrereleaseBaseHeight.set -> void
 Verlite.VersionCalculationOptions.QueryRemoteTags.get -> bool

--- a/src/Verlite.Core/VersionCalculationOptions.cs
+++ b/src/Verlite.Core/VersionCalculationOptions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Verlite
@@ -19,7 +20,7 @@ namespace Verlite
 		/// <summary>
 		/// If the destined version is not found or is below this value, it will be bumped up to this.
 		/// </summary>
-		public SemVer MinimiumVersion { get; set; } = new SemVer(0, 1, 0);
+		public SemVer MinimumVersion { get; set; } = new SemVer(0, 1, 0);
 		/// <summary>
 		/// The height to start with on non-tagged prereleases (the 4 value in 1.2.3-alpha.4).
 		/// </summary>
@@ -40,5 +41,15 @@ namespace Verlite
 		/// The component to bump in the semantic version post RTM release.
 		/// </summary>
 		public VersionPart AutoIncrement { get; set; } = VersionPart.Patch;
+
+		/// <summary>
+		/// Obsoleted due to a typo. Using this will redirect to the suggested replacement of <see cref="MinimumVersion"/> instead.
+		/// </summary>
+		[Obsolete("Use MinimumVersion instead.")]
+		public SemVer MinimiumVersion
+		{
+			get => MinimumVersion;
+			set => MinimumVersion = value;
+		}
 	}
 }

--- a/src/Verlite.Core/VersionCalculator.cs
+++ b/src/Verlite.Core/VersionCalculator.cs
@@ -37,8 +37,8 @@ namespace Verlite
 		/// <returns>The next version calculated from the input.</returns>
 		public static SemVer NextVersion(SemVer lastTag, VersionCalculationOptions options)
 		{
-			if (options.MinimiumVersion > lastTag.DestinedVersion)
-				return options.MinimiumVersion;
+			if (options.MinimumVersion > lastTag.DestinedVersion)
+				return options.MinimumVersion;
 			else if (lastTag.Prerelease is not null)
 				return lastTag;
 			else
@@ -62,13 +62,13 @@ namespace Verlite
 		public static SemVer FromTagInfomation(SemVer? lastTag, VersionCalculationOptions options, int height)
 		{
 			if (lastTag is null)
-				return Bump(options.MinimiumVersion, options, height);
+				return Bump(options.MinimumVersion, options, height);
 
 			bool directTag = height == 0;
 			if (directTag)
 			{
-				if (options.MinimiumVersion > lastTag.Value.DestinedVersion)
-					throw new VersionCalculationException($"Direct tag ({lastTag.Value}) destined version ({lastTag.Value.DestinedVersion}) is below the minimum version ({options.MinimiumVersion}).");
+				if (options.MinimumVersion > lastTag.Value.DestinedVersion)
+					throw new VersionCalculationException($"Direct tag ({lastTag.Value}) destined version ({lastTag.Value.DestinedVersion}) is below the minimum version ({options.MinimumVersion}).");
 
 				return lastTag.Value;
 			}

--- a/src/Verlite.Core/mark-shipped.sh
+++ b/src/Verlite.Core/mark-shipped.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eou pipefail
 
+cd "$(dirname "$0")"
+
 shipped="$(cat PublicAPI.Shipped.txt PublicAPI.Unshipped.txt \
 	| sort --ignore-case \
 	| uniq)"

--- a/src/Verlite.MsBuild/GetVersionTask.cs
+++ b/src/Verlite.MsBuild/GetVersionTask.cs
@@ -84,9 +84,8 @@ namespace Verlite.MsBuild
 					opts.DefaultPrereleasePhase = DefaultPrereleasePhase;
 
 				if (!string.IsNullOrWhiteSpace(MinimumVersion))
-					opts.MinimiumVersion = DecodeVersion(
+					opts.MinimumVersion = DecodeVersion(
 						MinimumVersion, nameof(MinimumVersion));
-
 
 				if (!string.IsNullOrWhiteSpace(PrereleaseBaseHeight))
 					opts.PrereleaseBaseHeight = DecodeInt(

--- a/tests/UnitTests/VersionCalculationTests.cs
+++ b/tests/UnitTests/VersionCalculationTests.cs
@@ -35,7 +35,7 @@ namespace UnitTests
 		{
 			var options = new VersionCalculationOptions()
 			{
-				MinimiumVersion = SemVer.Parse(minVer ?? "0.1.0"),
+				MinimumVersion = SemVer.Parse(minVer ?? "0.1.0"),
 			};
 
 			var version = versionStr is null ? (SemVer?)null: SemVer.Parse(versionStr);
@@ -97,7 +97,7 @@ namespace UnitTests
 			Assert.Throws<VersionCalculationException>(
 				() => VersionCalculator.FromTagInfomation(
 					lastTag: new(1, 0, 0),
-					options: new() { MinimiumVersion = new(2, 0, 0) },
+					options: new() { MinimumVersion = new(2, 0, 0) },
 					height: 0));
 		}
 


### PR DESCRIPTION
Renamed MinimiumVersion to MinimumVersion, and added a new deprecated
property for backwards compatibility.