### PR TITLE
Allow overriding Verlite.CLI's target framework.

### DIFF
--- a/src/Verlite.CLI/Verlite.CLI.csproj
+++ b/src/Verlite.CLI/Verlite.CLI.csproj
@@ -1,6 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFrameworks>netcoreapp2.1;net5.0;</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>verlite</ToolCommandName>

--- a/src/Verlite.Core/Verlite.Core.csproj
+++ b/src/Verlite.Core/Verlite.Core.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <Description>Core primitives and logic for automatic versioning via Git tags.</Description>
     <RootNamespace>Verlite</RootNamespace>
   </PropertyGroup>

--- a/tests/IntegrationTests/run.sh
+++ b/tests/IntegrationTests/run.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 cd "$(dirname $0)"
 
 export VERBOSE=""
+export REPO_PATH="$(git rev-parse --show-toplevel)"
 
 # setup the packages as version 0.0.0
 export NUGET_PACKAGES="$(mktemp -d)"
@@ -59,5 +60,6 @@ test branch-follows-first-parent
 test msbuild
 test multiple-tags-on-same-commit
 test auto-fetch
+test publish-different-framework
 
 echo "All complete."

--- a/tests/IntegrationTests/tests/publish-different-framework.sh
+++ b/tests/IntegrationTests/tests/publish-different-framework.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -euo pipefail
+
+git clone "$REPO_PATH" verlite > /dev/null 2> /dev/null
+
+dotnet publish \
+    verlite/src/Verlite.CLI/Verlite.CLI.csproj \
+    -o artifacts \
+    -p:TargetFramework=net5.0 \
+    -p:PackAsTool=false \
+> /dev/null 2> /dev/null
+
+dotnet publish \
+    verlite/src/Verlite.CLI/Verlite.CLI.csproj \
+    -o artifacts2 \
+    -f=net5.0 \
+    -p:PackAsTool=false \
+> /dev/null 2> /dev/null
+
+should-exist() {
+	if [[ ! -f "$1" ]]; then
+		echo "Missing artifact: $1"
+		exit 1
+	fi
+}
+
+should-exist artifacts/Verlite.CLI.dll
+should-exist artifacts2/Verlite.CLI.dll


### PR DESCRIPTION
This makes it easier for third parties to package Verlite.CLI by using `/p:TargetFramework=...`, without encountering this error:

```
Sdks\Microsoft.NET.Sdk\targets\Microsoft.PackageDependencyResolution.targets(246,5): error NETSDK1005: Assets file '...\src\Verlite.CLI\obj\project.assets.json' doesn't have a target for 'net5.0'. Ensure that restore has run and that you have included 'net5.0' in the TargetFrameworks for your project. [C:\Git\VerliteMaster\src\Verlite.CLI\Verlite.CLI.csproj]
```
