### PR TITLE
Deprecating old API in preparation for new API in 2.0.0

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,7 +46,7 @@
     <MinVerTagPrefix>v</MinVerTagPrefix>
     <!-- delete/set to patch the line below once almost out of v0.x.y (preferably once on a beta or rc). -->
     <MinVerAutoIncrement>patch</MinVerAutoIncrement>
-    <MinVerMinimumMajorMinor>1.1</MinVerMinimumMajorMinor>
+    <MinVerMinimumMajorMinor>1.2</MinVerMinimumMajorMinor>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MinVer" Version="2.5.0">

--- a/src/Verlite.Core/IRepoInspector.cs
+++ b/src/Verlite.Core/IRepoInspector.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using System.Threading.Tasks;
@@ -74,7 +75,14 @@ namespace Verlite
 		/// </summary>
 		/// <param name="commit">The commit.</param>
 		/// <returns>A task containing the primary parent commit, or <c>null</c> if it has none.</returns>
+		[Obsolete("Deprecated in favor of GetParents(). See GitHub issue #40.", error: false)]
 		Task<Commit?> GetParent(Commit commit);
+		/// <summary>
+		/// Gets all parents of the specified commit.
+		/// </summary>
+		/// <param name="commit">The commit.</param>
+		/// <returns>A task containing a list of parent commits.</returns>
+		Task<IReadOnlyList<Commit>> GetParents(Commit commit);
 		/// <summary>
 		/// Query tags from a desired target.
 		/// </summary>

--- a/src/Verlite.Core/IRepoInspector.cs
+++ b/src/Verlite.Core/IRepoInspector.cs
@@ -94,6 +94,12 @@ namespace Verlite
 		/// </summary>
 		/// <param name="tag">The tag to fetch.</param>
 		/// <param name="remote">Which remote to fetch the tag from.</param>
+		[Obsolete("Use FetchTag(tag)", error: false)]
 		Task FetchTag(Tag tag, string remote);
+		/// <summary>
+		/// Fetches the specified tag from the remote.
+		/// </summary>
+		/// <param name="tag">The tag to fetch.</param>
+		Task FetchTag(Tag tag);
 	}
 }

--- a/src/Verlite.Core/PublicAPI.Shipped.txt
+++ b/src/Verlite.Core/PublicAPI.Shipped.txt
@@ -14,7 +14,11 @@ static Verlite.Command.ParseCommandLine(string! cmdLine) -> System.Collections.G
 static Verlite.Command.Run(string! directory, string! command, string![]! args, System.Collections.Generic.IDictionary<string!, string!>? envVars = null) -> System.Threading.Tasks.Task<(string! stdout, string! stderr)>!
 static Verlite.Commit.operator !=(Verlite.Commit left, Verlite.Commit right) -> bool
 static Verlite.Commit.operator ==(Verlite.Commit left, Verlite.Commit right) -> bool
-static Verlite.GitRepoInspector.FromPath(string! path, Verlite.ILogger? log = null, Verlite.ICommandRunner? commandRunner = null) -> System.Threading.Tasks.Task<Verlite.GitRepoInspector!>!
+static Verlite.GitRepoInspector.FromPath(string! path) -> System.Threading.Tasks.Task<Verlite.GitRepoInspector!>!
+static Verlite.GitRepoInspector.FromPath(string! path, string! remote, Verlite.ILogger? log, Verlite.ICommandRunner! commandRunner) -> System.Threading.Tasks.Task<Verlite.GitRepoInspector!>!
+static Verlite.GitRepoInspector.FromPath(string! path, Verlite.ICommandRunner? commandRunner) -> System.Threading.Tasks.Task<Verlite.GitRepoInspector!>!
+static Verlite.GitRepoInspector.FromPath(string! path, Verlite.ILogger? log) -> System.Threading.Tasks.Task<Verlite.GitRepoInspector!>!
+static Verlite.GitRepoInspector.FromPath(string! path, Verlite.ILogger? log, Verlite.ICommandRunner? commandRunner) -> System.Threading.Tasks.Task<Verlite.GitRepoInspector!>!
 static Verlite.HeightCalculator.FromRepository(Verlite.IRepoInspector! repo, string! tagPrefix, bool queryRemoteTags, Verlite.ILogger? log = null, Verlite.ITagFilter? tagFilter = null) -> System.Threading.Tasks.Task<(int height, Verlite.TaggedVersion?)>!
 static Verlite.SemVer.ComparePrerelease(string! left, string! right) -> int
 static Verlite.SemVer.IsValidIdentifierCharacter(char input) -> bool
@@ -57,6 +61,7 @@ Verlite.GitMissingOrNotGitRepoException.GitMissingOrNotGitRepoException() -> voi
 Verlite.GitRepoInspector
 Verlite.GitRepoInspector.CanDeepen.get -> bool
 Verlite.GitRepoInspector.CanDeepen.set -> void
+Verlite.GitRepoInspector.FetchTag(Verlite.Tag tag) -> System.Threading.Tasks.Task!
 Verlite.GitRepoInspector.FetchTag(Verlite.Tag tag, string! remote) -> System.Threading.Tasks.Task!
 Verlite.GitRepoInspector.GetHead() -> System.Threading.Tasks.Task<Verlite.Commit?>!
 Verlite.GitRepoInspector.GetParent(Verlite.Commit commit) -> System.Threading.Tasks.Task<Verlite.Commit?>!
@@ -71,6 +76,7 @@ Verlite.ILogger.Normal(string! message) -> void
 Verlite.ILogger.Verbatim(string! message) -> void
 Verlite.ILogger.Verbose(string! message) -> void
 Verlite.IRepoInspector
+Verlite.IRepoInspector.FetchTag(Verlite.Tag tag) -> System.Threading.Tasks.Task!
 Verlite.IRepoInspector.FetchTag(Verlite.Tag tag, string! remote) -> System.Threading.Tasks.Task!
 Verlite.IRepoInspector.GetHead() -> System.Threading.Tasks.Task<Verlite.Commit?>!
 Verlite.IRepoInspector.GetParent(Verlite.Commit commit) -> System.Threading.Tasks.Task<Verlite.Commit?>!

--- a/src/Verlite.Core/PublicAPI.Shipped.txt
+++ b/src/Verlite.Core/PublicAPI.Shipped.txt
@@ -60,6 +60,7 @@ Verlite.GitRepoInspector.CanDeepen.set -> void
 Verlite.GitRepoInspector.FetchTag(Verlite.Tag tag, string! remote) -> System.Threading.Tasks.Task!
 Verlite.GitRepoInspector.GetHead() -> System.Threading.Tasks.Task<Verlite.Commit?>!
 Verlite.GitRepoInspector.GetParent(Verlite.Commit commit) -> System.Threading.Tasks.Task<Verlite.Commit?>!
+Verlite.GitRepoInspector.GetParents(Verlite.Commit commit) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Verlite.Commit>!>!
 Verlite.GitRepoInspector.GetTags(Verlite.QueryTarget queryTarget) -> System.Threading.Tasks.Task<Verlite.TagContainer!>!
 Verlite.GitRepoInspector.Root.get -> string!
 Verlite.HeightCalculator
@@ -73,6 +74,7 @@ Verlite.IRepoInspector
 Verlite.IRepoInspector.FetchTag(Verlite.Tag tag, string! remote) -> System.Threading.Tasks.Task!
 Verlite.IRepoInspector.GetHead() -> System.Threading.Tasks.Task<Verlite.Commit?>!
 Verlite.IRepoInspector.GetParent(Verlite.Commit commit) -> System.Threading.Tasks.Task<Verlite.Commit?>!
+Verlite.IRepoInspector.GetParents(Verlite.Commit commit) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Verlite.Commit>!>!
 Verlite.IRepoInspector.GetTags(Verlite.QueryTarget queryTarget) -> System.Threading.Tasks.Task<Verlite.TagContainer!>!
 Verlite.ITagFilter
 Verlite.ITagFilter.PassesFilter(Verlite.TaggedVersion! taggedVersion) -> System.Threading.Tasks.Task<bool>!

--- a/src/Verlite.Core/mark-shipped.sh
+++ b/src/Verlite.Core/mark-shipped.sh
@@ -5,6 +5,7 @@ cd "$(dirname "$0")"
 
 shipped="$(cat PublicAPI.Shipped.txt PublicAPI.Unshipped.txt \
 	| sort --ignore-case \
+	| awk '{$1=$1};1' \
 	| uniq)"
 
 echo "$shipped" > PublicAPI.Shipped.txt

--- a/tests/UnitTests/GitRepoInspectorTests.cs
+++ b/tests/UnitTests/GitRepoInspectorTests.cs
@@ -244,7 +244,7 @@ namespace UnitTests
 			firstTags.Should().ContainSingle();
 			var firstTag = firstTags[0];
 
-			await repo.FetchTag(firstTag, "origin");
+			await repo.FetchTag(firstTag);
 
 			var localTags = await repo.GetTags(QueryTarget.Local);
 			localTags.Should().Contain(new Tag[]
@@ -347,7 +347,7 @@ namespace UnitTests
 				.Where(tag => tag.Name == "tag-two")
 				.First();
 
-			await repo.FetchTag(desiredTag, "origin");
+			await repo.FetchTag(desiredTag);
 
 			var desiredParent = await repo.GetParent(desiredTag.PointsTo);
 			desiredParent.Should().Be(deeperTag.PointsTo);
@@ -384,7 +384,7 @@ namespace UnitTests
 				.Where(tag => tag.Name == "tag-two")
 				.First();
 
-			await repo.FetchTag(desiredTag, "origin");
+			await repo.FetchTag(desiredTag);
 			repo = null; // repo modified invalidating internal cache, so remake inspector
 			repo = await clone.MakeInspector();
 
@@ -422,7 +422,7 @@ namespace UnitTests
 			var filteredHistory = mockCommandRunner.CommandHistory
 				.Where(cmd => cmd.Contains("git fetch", StringComparison.Ordinal))
 				.Select(cmd =>
-					cmd.Contains("origin", StringComparison.Ordinal) ?
+					!cmd.Contains("origin --depth", StringComparison.Ordinal) ?
 						"normal fetch" :
 						"legacy fetch");
 

--- a/tests/UnitTests/HeightCalculationTests.cs
+++ b/tests/UnitTests/HeightCalculationTests.cs
@@ -18,8 +18,8 @@ namespace UnitTests
 		{
 			var repo = new MockRepoInspector(new MockRepoCommit[]
 			{
-				new("commit_a", "v1.0.0"),
-				new("commit_b", "v1.0.0-alpha.1"),
+				new("commit_a") { Tags = new[]{ "v1.0.0" } },
+				new("commit_b") { Tags = new[]{ "v1.0.0-alpha.1" } },
 				new("commit_c"),
 			});
 
@@ -80,7 +80,7 @@ namespace UnitTests
 		{
 			var repo = new MockRepoInspector(new MockRepoCommit[]
 			{
-				new("commit_a", "v1.0.0.0"),
+				new("commit_a") { Tags = new[]{ "v1.0.0.0" } },
 				new("commit_b"),
 				new("commit_c"),
 			});
@@ -97,9 +97,9 @@ namespace UnitTests
 		{
 			var repo = new MockRepoInspector(new MockRepoCommit[]
 			{
-				new("commit_a", "vast-tag"),
-				new("commit_b", "very-nice-tag"),
-				new("commit_c", "v"),
+				new("commit_a") { Tags = new[]{ "vast-tag" } },
+				new("commit_b") { Tags = new[]{ "very-nice-tag" } },
+				new("commit_c") { Tags = new[]{ "v" } },
 			});
 
 			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", true);
@@ -113,7 +113,7 @@ namespace UnitTests
 		{
 			var repo = new MockRepoInspector(new MockRepoCommit[]
 			{
-				new("commit_a", "v1.0.0-alpha.1", "v1.0.0", "v1.0.0-rc.1"),
+				new("commit_a") { Tags = new[]{ "v1.0.0-alpha.1", "v1.0.0", "v1.0.0-rc.1" } },
 				new("commit_b"),
 				new("commit_c"),
 			});
@@ -135,7 +135,7 @@ namespace UnitTests
 			var repo = new MockRepoInspector(new MockRepoCommit[]
 			{
 				new("commit_a"),
-				new("commit_b", "v1.0.0-alpha.1", "v1.0.0-rc.2", "v1.0.0-rc.10"),
+				new("commit_b") { Tags = new[]{ "v1.0.0-alpha.1", "v1.0.0-rc.2", "v1.0.0-rc.10" } },
 				new("commit_c"),
 			});
 
@@ -158,7 +158,7 @@ namespace UnitTests
 			{
 				new("commit_a"),
 				new("commit_b"),
-				new("commit_c", "v1.0.0-alpha.1"),
+				new("commit_c") { Tags = new[]{ "v1.0.0-alpha.1" } },
 			});
 
 			(_, _) = await HeightCalculator.FromRepository(repo, "v", true);
@@ -176,9 +176,9 @@ namespace UnitTests
 		{
 			var repo = new MockRepoInspector(new MockRepoCommit[]
 			{
-				new("commit_a", "abc/version/2.0.0"),
-				new("commit_b", "version/3.0.0"),
-				new("commit_c", "4.0.0"),
+				new("commit_a") { Tags = new[]{ "abc/version/2.0.0" } },
+				new("commit_b") { Tags = new[]{ "version/3.0.0" } },
+				new("commit_c") { Tags = new[]{ "4.0.0" } },
 				new("commit_d"),
 			});
 
@@ -209,8 +209,8 @@ namespace UnitTests
 		{
 			var repo = new MockRepoInspector(new MockRepoCommit[]
 			{
-				new("commit_a", "v1.0.0"),
-				new("commit_b", "v1.0.0-alpha.1"),
+				new("commit_a") { Tags = new[]{ "v1.0.0" } },
+				new("commit_b") { Tags = new[]{ "v1.0.0-alpha.1" } },
 				new("commit_c"),
 			});
 
@@ -232,8 +232,8 @@ namespace UnitTests
 		{
 			var repo = new MockRepoInspector(new MockRepoCommit[]
 			{
-				new("commit_a", "v1.0.0", "v1.0.1"),
-				new("commit_b", "v1.0.0-alpha.1"),
+				new("commit_a") { Tags = new[]{ "v1.0.0", "v1.0.1" } },
+				new("commit_b") { Tags = new[]{ "v1.0.0-alpha.1" } },
 				new("commit_c"),
 			});
 

--- a/tests/UnitTests/Mocks/MockCommandRunnerWithOldRemoteGitVersion.cs
+++ b/tests/UnitTests/Mocks/MockCommandRunnerWithOldRemoteGitVersion.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -30,12 +31,15 @@ namespace UnitTests
 			else
 				commandHistory.Add($"{command} {string.Join(' ', args)}");
 
-			return (command, firstArg, args) switch
+			if (firstArg == "fetch")
 			{
-				("git", "fetch", _) when args.Contains("origin") =>
-					throw new CommandException(128, "", "error: Server does not allow request for unadvertised object a1b2c3"),
-				_ => BaseRunner.Run(directory, command, args, envVars),
-			};
+				if (args.Length is not 3 and not 4)
+					throw new NotSupportedException();
+				if (args.Length == 4 && !args[2].StartsWith("--depth", StringComparison.Ordinal))
+					throw new CommandException(128, "", "error: Server does not allow request for unadvertised object a1b2c3");
+			}
+
+			return BaseRunner.Run(directory, command, args, envVars);
 		}
 	}
 }

--- a/tests/UnitTests/Mocks/MockRepoInspector.cs
+++ b/tests/UnitTests/Mocks/MockRepoInspector.cs
@@ -59,7 +59,12 @@ namespace UnitTests
 			Commits.Reverse(); // reverse it to make First the HEAD.
 		}
 
-		async Task IRepoInspector.FetchTag(Tag tag, string remote)
+		Task IRepoInspector.FetchTag(Tag tag, string remote)
+		{
+			return (this as IRepoInspector).FetchTag(tag);
+		}
+
+		async Task IRepoInspector.FetchTag(Tag tag)
 		{
 			if (LocalTags.Contains(tag))
 				return;

--- a/tests/UnitTests/UnitTests.csproj
+++ b/tests/UnitTests/UnitTests.csproj
@@ -10,8 +10,11 @@
 
 
   <ItemGroup>
+    <Compile Remove="StrykerOutput\**" />
     <Compile Remove="TestResults\**" />
+    <EmbeddedResource Remove="StrykerOutput\**" />
     <EmbeddedResource Remove="TestResults\**" />
+    <None Remove="StrykerOutput\**" />
     <None Remove="TestResults\**" />
   </ItemGroup>
 

--- a/tests/UnitTests/VersionCalculationTests.cs
+++ b/tests/UnitTests/VersionCalculationTests.cs
@@ -131,7 +131,7 @@ namespace UnitTests
 		{
 			var repo = new MockRepoInspector(new MockRepoCommit[]
 			{
-				new("commit_a", "v5.4.3-rc.2.1"),
+				new("commit_a") { Tags = new[] { "v5.4.3-rc.2.1" } },
 			});
 
 			var semver = await VersionCalculator.FromRepository(repo, new() { QueryRemoteTags = true });
@@ -145,7 +145,7 @@ namespace UnitTests
 			var repo = new MockRepoInspector(new MockRepoCommit[]
 			{
 				new("commit_b"),
-				new("commit_a", "v4.3.2-rc.1"),
+				new("commit_a") { Tags = new[] { "v4.3.2-rc.1" } },
 			});
 
 			var semver = await VersionCalculator.FromRepository(repo, new() { QueryRemoteTags = true });
@@ -159,7 +159,7 @@ namespace UnitTests
 			var repo = new MockRepoInspector(new MockRepoCommit[]
 			{
 				new("commit_b"),
-				new("commit_a", "v3.2.1"),
+				new("commit_a") { Tags = new[] { "v3.2.1" } },
 			});
 
 			var semver = await VersionCalculator.FromRepository(repo, new() { QueryRemoteTags = true });
@@ -173,8 +173,8 @@ namespace UnitTests
 			var repo = new MockRepoInspector(new MockRepoCommit[]
 			{
 				new("commit_c"),
-				new("commit_b", "v3.2.1"),
-				new("commit_a", "v3.2.0"),
+				new("commit_b") { Tags = new[] { "v3.2.1" } },
+				new("commit_a") { Tags = new[] { "v3.2.0" } },
 			});
 
 			_ = await VersionCalculator.FromRepository(repo, new() { QueryRemoteTags = true });
@@ -188,8 +188,8 @@ namespace UnitTests
 			var repo = new MockRepoInspector(new MockRepoCommit[]
 			{
 				new("commit_c"),
-				new("commit_b", "v3.2.1"),
-				new("commit_a", "v3.2.0"),
+				new("commit_b") { Tags = new[] { "v3.2.1" } },
+				new("commit_a") { Tags = new[] { "v3.2.0" } },
 			});
 
 			_ = await VersionCalculator.FromRepository(repo, new() { QueryRemoteTags = false });


### PR DESCRIPTION
- Refactor: Add `IRepoInspector.GetParents()`, deprecating `GetParent()`. *(required for #40)*
- Deprecate `FetchTag(tag, remote)` in favor of a ctor injected remote.
- Deprecated `GitRepoInspector.FromPath()` with optional arguments.

The `GitRepoInspector`'s implementation of `GetParents()` matches the current behavior of only using the first parent. This will be fixed in 2.0.0.