### PR TITLE
Remove deprecated APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,13 @@ See [docs/VersionCalculation.md](docs/VersionCalculation.md) for further reading
 | The minimum RTM version, i.e the destined version.                  | -m, --min-version, VerliteMinimumVersion                         | 0.1.0   |
 | The height for continuous deliverable auto heights should begin at. | -p, --prerelease-base-height, VerlitePrereleaseBaseHeight        | 1       |
 | Force the calculated version to be this version.                    | --version-override, VerliteVersionOverride                       |         |
-| Logging level.                                                      | --verbosity, VerliteVerbosity                                    | Normal  |
+| Logging level.                                                      | --verbosity, VerliteVerbosity                                    | normal  |
 | Set the build data to this value.                                   | -b, --build-metadata, VerliteBuildMetadata                       |         |
-| Part of the version to print.                                       | -s, --show                                                       | All     |
+| Part of the version to print.                                       | -s, --show                                                       | all     |
 | Automatically fetch commits and a tag for shallow clones.           | --auto-fetch                                                     | false   |
 | Set which version part should be bumped after an RTM release.       | -a, --auto-increment, VerliteAutoIncrement                       | patch   |
 | A command to test whether a tag should be ignored via exit code.    | -f, --filter-tags, VerliteFilterTags                             |         |
+| The remote endpoint to use when fetching tags and commits.          | -r, --remote, VerliteRemote                                      | origin  |
 
 ## Comparison with GitVersion
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,9 @@
 comment: false
+coverage:
+  status:
+    project:
+      default:
+        only_pulls: true
+    patch:
+      default:
+        only_pulls: true

--- a/src/Verlite.CLI/Program.cs
+++ b/src/Verlite.CLI/Program.cs
@@ -90,6 +90,10 @@ namespace Verlite.CLI
 					aliases: new[] { "--filter-tags", "-f" },
 					getDefaultValue: () => string.Empty,
 					description: "Specify a command to execute, an exit code of 0 will not filter the tag."),
+				new Option<string>(
+					aliases: new[] { "--remote", "-r" },
+					getDefaultValue: () => DefaultOptions.Remote,
+					description: "The remote endpoint to use when fetching tags and commits."),
 			};
 			rootCommand.WithHandler(nameof(RootCommandAsync));
 			return await rootCommand.InvokeAsync(args);
@@ -107,6 +111,7 @@ namespace Verlite.CLI
 			bool autoFetch,
 			AutoIncrement autoIncrement,
 			string filterTags,
+			string remote,
 			string sourceDirectory)
 		{
 			try
@@ -127,12 +132,13 @@ namespace Verlite.CLI
 					BuildMetadata = buildMetadata,
 					QueryRemoteTags = autoFetch,
 					AutoIncrement = autoIncrement.Value(),
+					Remote = remote,
 				};
 
 				var version = opts.VersionOverride ?? new SemVer();
 				if (opts.VersionOverride is null)
 				{
-					using var repo = await GitRepoInspector.FromPath(sourceDirectory, log, commandRunner);
+					using var repo = await GitRepoInspector.FromPath(sourceDirectory, opts.Remote, log, commandRunner);
 					repo.CanDeepen = autoFetch;
 
 					ITagFilter? tagFilter = null;

--- a/src/Verlite.Core/GitRepoInspector.cs
+++ b/src/Verlite.Core/GitRepoInspector.cs
@@ -38,26 +38,6 @@ namespace Verlite
 	/// <seealso cref="IRepoInspector"/>
 	public sealed class GitRepoInspector : IRepoInspector, IDisposable
 	{
-#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
-		// TODO: Remove all of these enumerated permutations of the old optional args in 2.0.0
-		[ExcludeFromCodeCoverage]
-		[Obsolete("Use FromPath(path, remote, log, commandRunner)", error: false)]
-		public static Task<GitRepoInspector> FromPath(string path, ILogger? log, ICommandRunner? commandRunner)
-			=> FromPath(path, "origin", log, commandRunner ?? new SystemCommandRunner());
-		[ExcludeFromCodeCoverage]
-		[Obsolete("Use FromPath(path, remote, log, commandRunner)", error: false)]
-		public static Task<GitRepoInspector> FromPath(string path, ILogger? log)
-			=> FromPath(path, "origin", log, new SystemCommandRunner());
-		[ExcludeFromCodeCoverage]
-		[Obsolete("Use FromPath(path, remote, log, commandRunner)", error: false)]
-		public static Task<GitRepoInspector> FromPath(string path, ICommandRunner? commandRunner)
-			=> FromPath(path, "origin", null, commandRunner?? new SystemCommandRunner());
-		[ExcludeFromCodeCoverage]
-		[Obsolete("Use FromPath(path, remote, log, commandRunner)", error: false)]
-		public static Task<GitRepoInspector> FromPath(string path)
-			=> FromPath(path, "origin", null, new SystemCommandRunner());
-#pragma warning restore CS1591 // Missing XML comment for publicly visible type or member
-
 		/// <summary>
 		/// Creates an inspector from the specified path.
 		/// </summary>
@@ -347,7 +327,7 @@ namespace Verlite
 			return parents;
 		}
 
-		private static readonly Regex RefsTagRegex = new Regex(
+		private static readonly Regex RefsTagRegex = new(
 			@"^(?<pointer>[a-zA-Z0-9]+)\s*refs/tags/(?<tag>.+?)(\^\{\})?$",
 			RegexOptions.Compiled | RegexOptions.Multiline | RegexOptions.ExplicitCapture);
 		private static IEnumerable<Tag> MatchTags(string commandOutput)

--- a/src/Verlite.Core/IRepoInspector.cs
+++ b/src/Verlite.Core/IRepoInspector.cs
@@ -70,14 +70,6 @@ namespace Verlite
 		/// <returns>A task containing the commit, or <c>null</c> if there is none.</returns>
 		Task<Commit?> GetHead();
 		/// <summary>
-		/// Gets the primary parent of the specified commit. <br/>
-		/// In DVCSs this is typically the first parent.
-		/// </summary>
-		/// <param name="commit">The commit.</param>
-		/// <returns>A task containing the primary parent commit, or <c>null</c> if it has none.</returns>
-		[Obsolete("Deprecated in favor of GetParents(). See GitHub issue #40.", error: false)]
-		Task<Commit?> GetParent(Commit commit);
-		/// <summary>
 		/// Gets all parents of the specified commit.
 		/// </summary>
 		/// <param name="commit">The commit.</param>
@@ -89,13 +81,6 @@ namespace Verlite
 		/// <param name="queryTarget">The target to query.</param>
 		/// <returns>A task containing a <see cref="TagContainer"/></returns>
 		Task<TagContainer> GetTags(QueryTarget queryTarget);
-		/// <summary>
-		/// Fetches the specified tag from the desired remote.
-		/// </summary>
-		/// <param name="tag">The tag to fetch.</param>
-		/// <param name="remote">Which remote to fetch the tag from.</param>
-		[Obsolete("Use FetchTag(tag)", error: false)]
-		Task FetchTag(Tag tag, string remote);
 		/// <summary>
 		/// Fetches the specified tag from the remote.
 		/// </summary>

--- a/src/Verlite.Core/PublicAPI.Shipped.txt
+++ b/src/Verlite.Core/PublicAPI.Shipped.txt
@@ -14,11 +14,7 @@ static Verlite.Command.ParseCommandLine(string! cmdLine) -> System.Collections.G
 static Verlite.Command.Run(string! directory, string! command, string![]! args, System.Collections.Generic.IDictionary<string!, string!>? envVars = null) -> System.Threading.Tasks.Task<(string! stdout, string! stderr)>!
 static Verlite.Commit.operator !=(Verlite.Commit left, Verlite.Commit right) -> bool
 static Verlite.Commit.operator ==(Verlite.Commit left, Verlite.Commit right) -> bool
-static Verlite.GitRepoInspector.FromPath(string! path) -> System.Threading.Tasks.Task<Verlite.GitRepoInspector!>!
 static Verlite.GitRepoInspector.FromPath(string! path, string! remote, Verlite.ILogger? log, Verlite.ICommandRunner! commandRunner) -> System.Threading.Tasks.Task<Verlite.GitRepoInspector!>!
-static Verlite.GitRepoInspector.FromPath(string! path, Verlite.ICommandRunner? commandRunner) -> System.Threading.Tasks.Task<Verlite.GitRepoInspector!>!
-static Verlite.GitRepoInspector.FromPath(string! path, Verlite.ILogger? log) -> System.Threading.Tasks.Task<Verlite.GitRepoInspector!>!
-static Verlite.GitRepoInspector.FromPath(string! path, Verlite.ILogger? log, Verlite.ICommandRunner? commandRunner) -> System.Threading.Tasks.Task<Verlite.GitRepoInspector!>!
 static Verlite.HeightCalculator.FromRepository(Verlite.IRepoInspector! repo, string! tagPrefix, bool queryRemoteTags, Verlite.ILogger? log = null, Verlite.ITagFilter? tagFilter = null) -> System.Threading.Tasks.Task<(int height, Verlite.TaggedVersion?)>!
 static Verlite.SemVer.ComparePrerelease(string! left, string! right) -> int
 static Verlite.SemVer.IsValidIdentifierCharacter(char input) -> bool
@@ -77,9 +73,7 @@ Verlite.ILogger.Verbatim(string! message) -> void
 Verlite.ILogger.Verbose(string! message) -> void
 Verlite.IRepoInspector
 Verlite.IRepoInspector.FetchTag(Verlite.Tag tag) -> System.Threading.Tasks.Task!
-Verlite.IRepoInspector.FetchTag(Verlite.Tag tag, string! remote) -> System.Threading.Tasks.Task!
 Verlite.IRepoInspector.GetHead() -> System.Threading.Tasks.Task<Verlite.Commit?>!
-Verlite.IRepoInspector.GetParent(Verlite.Commit commit) -> System.Threading.Tasks.Task<Verlite.Commit?>!
 Verlite.IRepoInspector.GetParents(Verlite.Commit commit) -> System.Threading.Tasks.Task<System.Collections.Generic.IReadOnlyList<Verlite.Commit>!>!
 Verlite.IRepoInspector.GetTags(Verlite.QueryTarget queryTarget) -> System.Threading.Tasks.Task<Verlite.TagContainer!>!
 Verlite.ITagFilter
@@ -143,8 +137,6 @@ Verlite.VersionCalculationOptions.BuildMetadata.get -> string?
 Verlite.VersionCalculationOptions.BuildMetadata.set -> void
 Verlite.VersionCalculationOptions.DefaultPrereleasePhase.get -> string!
 Verlite.VersionCalculationOptions.DefaultPrereleasePhase.set -> void
-Verlite.VersionCalculationOptions.MinimiumVersion.get -> Verlite.SemVer
-Verlite.VersionCalculationOptions.MinimiumVersion.set -> void
 Verlite.VersionCalculationOptions.MinimumVersion.get -> Verlite.SemVer
 Verlite.VersionCalculationOptions.MinimumVersion.set -> void
 Verlite.VersionCalculationOptions.PrereleaseBaseHeight.get -> int

--- a/src/Verlite.Core/PublicAPI.Unshipped.txt
+++ b/src/Verlite.Core/PublicAPI.Unshipped.txt
@@ -3,3 +3,5 @@ Verlite.GitRepoInspector.Dispose() -> void
 Verlite.GitRepoInspector.Remote.get -> string!
 Verlite.UnknownGitException
 Verlite.UnknownGitException.UnknownGitException(string! message) -> void
+Verlite.VersionCalculationOptions.Remote.get -> string!
+Verlite.VersionCalculationOptions.Remote.set -> void

--- a/src/Verlite.Core/VersionCalculationOptions.cs
+++ b/src/Verlite.Core/VersionCalculationOptions.cs
@@ -41,15 +41,9 @@ namespace Verlite
 		/// The component to bump in the semantic version post RTM release.
 		/// </summary>
 		public VersionPart AutoIncrement { get; set; } = VersionPart.Patch;
-
 		/// <summary>
-		/// Obsoleted due to a typo. Using this will redirect to the suggested replacement of <see cref="MinimumVersion"/> instead.
+		/// The remote endpoint to use when fetching tags and commits.
 		/// </summary>
-		[Obsolete("Use MinimumVersion instead.")]
-		public SemVer MinimiumVersion
-		{
-			get => MinimumVersion;
-			set => MinimumVersion = value;
-		}
+		public string Remote { get; set; } = "origin";
 	}
 }

--- a/src/Verlite.Core/VersionCalculator.cs
+++ b/src/Verlite.Core/VersionCalculator.cs
@@ -113,7 +113,7 @@ namespace Verlite
 				if (!localTag.Any())
 				{
 					log?.Normal("Local repo missing version tag, fetching.");
-					await repo.FetchTag(lastTagVer.Tag, "origin");
+					await repo.FetchTag(lastTagVer.Tag);
 				}
 			}
 

--- a/src/Verlite.MsBuild/GetVersionTask.cs
+++ b/src/Verlite.MsBuild/GetVersionTask.cs
@@ -20,6 +20,7 @@ namespace Verlite.MsBuild
 		public string PrereleaseBaseHeight { get; set; } = "";
 		public string AutoIncrement { get; set; } = "";
 		public string FilterTags { get; set; } = "";
+		public string Remote { get; set; } = "";
 
 		public override bool Execute()
 		{
@@ -101,12 +102,15 @@ namespace Verlite.MsBuild
 				if (!string.IsNullOrWhiteSpace(AutoIncrement))
 					opts.AutoIncrement = DecodeVersionPart(
 						AutoIncrement, nameof(AutoIncrement));
+
+				if (!string.IsNullOrWhiteSpace(Remote))
+					opts.Remote = Remote;
 			}
 
 			var version = opts.VersionOverride ?? new SemVer();
 			if (opts.VersionOverride is null)
 			{
-				using var repo = await GitRepoInspector.FromPath(ProjectDirectory, log, commandRunner);
+				using var repo = await GitRepoInspector.FromPath(ProjectDirectory, opts.Remote, log, commandRunner);
 
 				ITagFilter? tagFilter = null;
 				if (!string.IsNullOrWhiteSpace(FilterTags))

--- a/src/Verlite.MsBuild/build/Verlite.MsBuild.targets
+++ b/src/Verlite.MsBuild/build/Verlite.MsBuild.targets
@@ -43,6 +43,7 @@ This file has been modified by Ashleigh Adams and adapted for Verlite -->
     <Message Importance="$(VerliteDetailed)" Text="Verlite: [input] VerlitePrereleaseBaseHeight=$(VerlitePrereleaseBaseHeight)" />
     <Message Importance="$(VerliteDetailed)" Text="Verlite: [input] VerliteAutoIncrement=$(VerliteAutoIncrement)" />
     <Message Importance="$(VerliteDetailed)" Text="Verlite: [input] VerliteFilterTags=$(VerliteFilterTags)" />
+    <Message Importance="$(VerliteDetailed)" Text="Verlite: [input] VerliteRemote=$(VerliteRemote)" />
 
     <Verlite.MsBuild.GetVersionTask ProjectDirectory="$(MSBuildProjectDirectory)"
                                     BuildMetadata="$(VerliteBuildMetadata)"
@@ -54,7 +55,8 @@ This file has been modified by Ashleigh Adams and adapted for Verlite -->
                                     VersionOverride="$(VerliteVersionOverride)"
                                     PrereleaseBaseHeight="$(VerlitePrereleaseBaseHeight)"
                                     AutoIncrement="$(VerliteAutoIncrement)"
-                                    FilterTags="$(VerliteFilterTags)" >
+                                    FilterTags="$(VerliteFilterTags)"
+                                    Remote="$(VerliteRemote)" >
       <Output TaskParameter="Version" PropertyName="VerliteVersion" />
       <Output TaskParameter="VersionMajor" PropertyName="VerliteMajor" />
       <Output TaskParameter="VersionMinor" PropertyName="VerliteMinor" />

--- a/tests/UnitTests/GitRepoInspectorTests.cs
+++ b/tests/UnitTests/GitRepoInspectorTests.cs
@@ -57,8 +57,9 @@ namespace UnitTests
 		{
 			return GitRepoInspector.FromPath(
 				path: RootPath,
+				remote: "origin",
 				log: null,
-				commandRunner);
+				commandRunner ?? new SystemCommandRunner());
 		}
 
 		public void Dispose()

--- a/tests/UnitTests/Mocks/MockRepoInspector.cs
+++ b/tests/UnitTests/Mocks/MockRepoInspector.cs
@@ -133,11 +133,6 @@ namespace UnitTests
 			Head = commits.Count > 0 ? commits[0].Id : null;
 		}
 
-		Task IRepoInspector.FetchTag(Tag tag, string remote)
-		{
-			return (this as IRepoInspector).FetchTag(tag);
-		}
-
 		async Task IRepoInspector.FetchTag(Tag tag)
 		{
 			if (LocalTags.Contains(tag))
@@ -149,14 +144,6 @@ namespace UnitTests
 		async Task<Commit?> IRepoInspector.GetHead()
 		{
 			return Head;
-		}
-
-		async Task<Commit?> IRepoInspector.GetParent(Commit commit)
-		{
-			var parents = await (this as IRepoInspector).GetParents(commit);
-			return parents
-				.Select(p => (Commit?)p)
-				.FirstOrDefault();
 		}
 
 		async Task<IReadOnlyList<Commit>> IRepoInspector.GetParents(Commit commit)


### PR DESCRIPTION
- Removed `GitRepoInspector.FromPath()` compatibility functions.
- Removed `IRepoInspector.FetchTag(tag, remote)`.
- Removed `IRepoInspector.GetParent(commit)`.
- Removed `VersionCalculationOptions.MinimiumVersion`.
- Added "remote" options to pass to the new core API.

Meta: codecov only status reports on PRs.
