### PR TITLE
Embed version strings using a source generator

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,7 +4,6 @@ High level of what was changed, possibly include why this approach was taken.
 
 Are there any concerns or areas to be aware of regarding the approach taken or areas changed?
 
-- [ ] Unit tests added
-- [ ] Integration tests
+- [ ] Tests added
 - [ ] Linked issue if exists
 - [ ] Updated documentation

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,7 +46,7 @@
     <MinVerTagPrefix>v</MinVerTagPrefix>
     <!-- delete/set to patch the line below once almost out of v0.x.y (preferably once on a beta or rc). -->
     <MinVerAutoIncrement>patch</MinVerAutoIncrement>
-    <MinVerMinimumMajorMinor>2.0</MinVerMinimumMajorMinor>
+    <MinVerMinimumMajorMinor>2.1</MinVerMinimumMajorMinor>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MinVer" Version="2.5.0">

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ See [docs/VersionCalculation.md](docs/VersionCalculation.md) for further reading
 | Set which version part should be bumped after an RTM release.       | -a, --auto-increment, VerliteAutoIncrement                       | patch   |
 | A command to test whether a tag should be ignored via exit code.    | -f, --filter-tags, VerliteFilterTags                             |         |
 | The remote endpoint to use when fetching tags and commits.          | -r, --remote, VerliteRemote                                      | origin  |
+| Generate version strings and embed them via a source generator.     | VerliteEmbedVersion                                              | true    |
 
 ## Comparison with GitVersion
 
@@ -105,6 +106,8 @@ Additionally, Verlite has some extra features, some of which I required or desir
  - [Can I use only signed/specific/arbitrary tags?](#filtering-tags) *(yes)*
  - [What is a good changelog strategy?](#changelog-strategy) *(changes since same or better stability)*
  - [What happens if tag buildmeta and options buildmeta are set?](#tag-and-option-meta) *(concatenated together)*
+ - [Can I access computed versions in my assembly?](#embedded-versions) *(yes)*
+ - [Can others access computed versions in the assembly?](#embedded-versions-visibility) *(no\*)*
 
 ### Why Verlite?
 
@@ -214,6 +217,42 @@ If a tag with height is being used, the build metadata is discarded, and the opt
 In the case of both tag without height and options having build metadata, they are concatenated together with a hash.
 
 Tagging a release as say, `v1.2.3+abc` and also specifying `--build-metadata xyz` will result in a final version of `1.2.3+abc-xyz`.
+
+<h3 id="embedded-versions">Can I access computed versions in my assembly?</h3>
+
+Yes, since v2.1, the computed versions are added by default using a source generator.
+This can be disabled by setting the `VerliteEmbedVersion` property to `false`.
+
+The embedded version is structured as follows:
+
+```cs
+namespace Verlite
+{
+	internal static class Version
+	{
+		public const string Full;
+		public const string Core;
+		public const string Major;
+		public const string Minor;
+		public const string Patch;
+		public const string Prerelease;
+		public const string BuildMetadata;
+	}
+}
+```
+
+<h3 id="embedded-versions-visibility">Can others access computed versions in the assembly?</h3>
+
+No, the generated structure is marked as `internal`, and only visible to your assembly.
+Should you wish to expose this version, it is recomended you use a public static property:
+
+```cs
+namespace MyLibrary;
+public static class Version
+{
+	public string Version => Verlite.Version.FullVersion;
+}
+```
 
 [verlite-msbuild-badge]: https://img.shields.io/nuget/v/Verlite.MsBuild?label=Verlite.MsBuild
 [verlite-msbuild-link]: https://www.nuget.org/packages/Verlite.MsBuild

--- a/src/Verlite.MsBuild/Verlite.MsBuild.csproj
+++ b/src/Verlite.MsBuild/Verlite.MsBuild.csproj
@@ -36,7 +36,7 @@
     <ItemGroup>
       <None Include="$(OutputPath)\**\*" Exclude="$(OutputPath)\**\*.dev.json" Pack="true" PackagePath="verlite" />
       <!-- Also put the dlls to register our analyzer -->
-      <None Include="$(OutputPath)\**\*" Exclude="$(OutputPath)\**\*.dev.json" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+      <None Include="$(OutputPath)\$(AssemblyName).dll" Exclude="$(OutputPath)\**\*.dev.json" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Verlite.MsBuild/Verlite.MsBuild.csproj
+++ b/src/Verlite.MsBuild/Verlite.MsBuild.csproj
@@ -25,6 +25,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.0.1"  PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>
@@ -34,6 +36,8 @@
   <Target Name="AddVerliteOutput" BeforeTargets="_GetPackageFiles">
     <ItemGroup>
       <None Include="$(OutputPath)\**\*" Exclude="$(OutputPath)\**\*.dev.json" Pack="true" PackagePath="verlite" />
+      <!-- Also put the dlls to register our analyzer -->
+      <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Verlite.MsBuild/Verlite.MsBuild.csproj
+++ b/src/Verlite.MsBuild/Verlite.MsBuild.csproj
@@ -25,8 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Build.Utilities.Core" Version="17.0.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="4.0.1"  PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.0.1" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.11.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -37,7 +36,7 @@
     <ItemGroup>
       <None Include="$(OutputPath)\**\*" Exclude="$(OutputPath)\**\*.dev.json" Pack="true" PackagePath="verlite" />
       <!-- Also put the dlls to register our analyzer -->
-      <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+      <None Include="$(OutputPath)\**\*" Exclude="$(OutputPath)\**\*.dev.json" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Verlite.MsBuild/Verlite.MsBuild.csproj
+++ b/src/Verlite.MsBuild/Verlite.MsBuild.csproj
@@ -36,7 +36,7 @@
     <ItemGroup>
       <None Include="$(OutputPath)\**\*" Exclude="$(OutputPath)\**\*.dev.json" Pack="true" PackagePath="verlite" />
       <!-- Also put the dlls to register our analyzer -->
-      <None Include="$(OutputPath)\$(AssemblyName).dll" Exclude="$(OutputPath)\**\*.dev.json" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+      <None Include="$(OutputPath)\Verlite.*.dll" Exclude="$(OutputPath)\**\*.dev.json" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     </ItemGroup>
   </Target>
 </Project>

--- a/src/Verlite.MsBuild/VersionEmbedGenerator.cs
+++ b/src/Verlite.MsBuild/VersionEmbedGenerator.cs
@@ -1,0 +1,60 @@
+using Microsoft.CodeAnalysis;
+
+
+namespace Verlite
+{
+	[Generator]
+	public class VersionEmbedGenerator : ISourceGenerator
+	{
+		public void Initialize(GeneratorInitializationContext context) { }
+
+		public void Execute(GeneratorExecutionContext context)
+		{
+			var assembly = context.Compilation.SourceModule.Name;
+
+			context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.VerliteEmbedVersion", out var embedVersion);
+
+			if (!string.IsNullOrEmpty(embedVersion) && embedVersion!.ToUpperInvariant() != "TRUE")
+				return;
+
+			context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.VerliteVersion", out var version);
+			context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.VerliteMajor", out var major);
+			context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.VerliteMinor", out var minor);
+			context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.VerlitePatch", out var patch);
+			context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.VerlitePrerelease", out var prerelease);
+			context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.VerliteBuildMetadata", out var meta);
+
+			version ??= string.Empty;
+			major ??= string.Empty;
+			minor ??= string.Empty;
+			patch ??= string.Empty;
+			prerelease ??= string.Empty;
+			meta ??= string.Empty;
+
+			var coreVersion = string.IsNullOrEmpty(version) ? string.Empty : $"{major}.{minor}.{patch}";
+
+			string source = $@"
+#pragma warning disable
+
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo(""{assembly}"")]
+
+namespace Verlite
+{{
+[global::System.Runtime.CompilerServices.CompilerGenerated]
+[global::System.Diagnostics.CodeAnalysis.ExcludeFromCodeCoverage]
+	internal static class Version
+	{{
+		public const string Full = ""{version}"";
+		public const string Core = ""{coreVersion}"";
+		public const string Major = ""{major}"";
+		public const string Minor = ""{minor}"";
+		public const string Patch = ""{patch}"";
+		public const string Prerelease = ""{prerelease}"";
+		public const string BuildMetadata = ""{meta}"";
+	}}
+}}
+";
+			context.AddSource($"Verlite.g.cs", source);
+		}
+	}
+}

--- a/src/Verlite.MsBuild/VersionEmbedGenerator.cs
+++ b/src/Verlite.MsBuild/VersionEmbedGenerator.cs
@@ -23,6 +23,7 @@ namespace Verlite
 			context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.VerlitePatch", out var patch);
 			context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.VerlitePrerelease", out var prerelease);
 			context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.VerliteBuildMetadata", out var meta);
+			context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.VerliteCommit", out var commit);
 
 			version ??= string.Empty;
 			major ??= string.Empty;
@@ -30,6 +31,7 @@ namespace Verlite
 			patch ??= string.Empty;
 			prerelease ??= string.Empty;
 			meta ??= string.Empty;
+			commit ??= string.Empty;
 
 			var coreVersion = string.IsNullOrEmpty(version) ? string.Empty : $"{major}.{minor}.{patch}";
 
@@ -51,6 +53,7 @@ namespace Verlite
 		public const string Patch = ""{patch}"";
 		public const string Prerelease = ""{prerelease}"";
 		public const string BuildMetadata = ""{meta}"";
+		public const string Commit = ""{commit}"";
 	}}
 }}
 ";

--- a/src/Verlite.MsBuild/build/Verlite.MsBuild.targets
+++ b/src/Verlite.MsBuild/build/Verlite.MsBuild.targets
@@ -15,7 +15,19 @@ This file has been modified by Ashleigh Adams and adapted for Verlite -->
   <PropertyGroup>
     <MSBuildAllProjects Condition="'$(MSBuildAssemblyVersion)' == '' Or '$(MSBuildAssemblyVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
     <GetPackageVersionDependsOn>$(GetPackageVersionDependsOn);Verlite</GetPackageVersionDependsOn>
+    <CoreCompileDependsOn>Verlite;$(CoreCompileDependsOn)</CoreCompileDependsOn>
   </PropertyGroup>
+
+  <!-- expose these variables to the source generator -->
+  <ItemGroup>
+    <CompilerVisibleProperty Include="VerliteEmbedVersion" />
+    <CompilerVisibleProperty Include="VerliteVersion" />
+    <CompilerVisibleProperty Include="VerliteMajor" />
+    <CompilerVisibleProperty Include="VerliteMinor" />
+    <CompilerVisibleProperty Include="VerlitePatch" />
+    <CompilerVisibleProperty Include="VerlitePrerelease" />
+    <CompilerVisibleProperty Include="VerliteBuildMetadata" />
+  </ItemGroup>
 
   <PropertyGroup>
     <VerliteDetailed>low</VerliteDetailed>
@@ -26,7 +38,7 @@ This file has been modified by Ashleigh Adams and adapted for Verlite -->
   </PropertyGroup>
 
   <Target Name="Verlite"
-          BeforeTargets="BeforeCompile;GetAssemblyVersion;CoreCompile;GenerateNuspec;_GenerateRestoreProjectSpec;_GetOutputItemsFromPack;EnsureWixToolsetInstalled"
+          BeforeTargets="PrepareForBuild;GenerateMSBuildEditorConfigFile;BeforeCompile;GetAssemblyVersion;CoreCompile;GenerateNuspec;_GenerateRestoreProjectSpec;_GetOutputItemsFromPack;EnsureWixToolsetInstalled"
           Condition="'$(DesignTimeBuild)' != 'true' AND '$(VerliteDisabled)' != 'true'">
 
     <Error Code="VERLITE0001" Condition="'$(UsingMicrosoftNETSdk)' != 'true'" Text="Verlite.MsBuild only works in SDK-style projects." />

--- a/src/Verlite.MsBuild/build/Verlite.MsBuild.targets
+++ b/src/Verlite.MsBuild/build/Verlite.MsBuild.targets
@@ -27,6 +27,7 @@ This file has been modified by Ashleigh Adams and adapted for Verlite -->
     <CompilerVisibleProperty Include="VerlitePatch" />
     <CompilerVisibleProperty Include="VerlitePrerelease" />
     <CompilerVisibleProperty Include="VerliteBuildMetadata" />
+    <CompilerVisibleProperty Include="VerliteCommit" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/tests/IntegrationTests/NuGet.conf.disabled
+++ b/tests/IntegrationTests/NuGet.conf.disabled
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <clear />
+    <!-- <clear /> -->
     <add key="local" value="packages" />
   </packageSources>
 </configuration>

--- a/tests/IntegrationTests/tests/msbuild.sh
+++ b/tests/IntegrationTests/tests/msbuild.sh
@@ -30,3 +30,5 @@ should-exist artifacts/TagPrefix.3.0.1-alpha.1.nupkg
 should-exist artifacts/TagFilter.1.0.1-alpha.1.nupkg
 should-exist artifacts/MinimumVersion.4.0.0-alpha.1.nupkg
 should-exist artifacts/VersionOverride.1.33.7.nupkg
+should-exist artifacts/EmbeddedVersion.1.0.1-alpha.1.nupkg
+should-exist artifacts/EmbeddedVersionDisabled.1.0.1-alpha.1.nupkg

--- a/tests/IntegrationTests/tests/msbuild/msbuild.sln
+++ b/tests/IntegrationTests/tests/msbuild/msbuild.sln
@@ -17,6 +17,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Normal", "src\Normal\Normal
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TagFilter", "src\TagFilter\TagFilter.csproj", "{3028EE8A-44B8-497B-8A17-5645AF517776}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EmbeddedVersion", "src\EmbeddedVersion\EmbeddedVersion.csproj", "{8076DEF6-6BBF-42B0-BF64-8270B74B24ED}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "EmbeddedVersionDisabled", "src\EmbeddedVersionDisabled\EmbeddedVersionDisabled.csproj", "{951D73B6-FF0A-444C-B5F0-80E0E35A5B72}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -111,6 +115,30 @@ Global
 		{3028EE8A-44B8-497B-8A17-5645AF517776}.Release|x64.Build.0 = Release|Any CPU
 		{3028EE8A-44B8-497B-8A17-5645AF517776}.Release|x86.ActiveCfg = Release|Any CPU
 		{3028EE8A-44B8-497B-8A17-5645AF517776}.Release|x86.Build.0 = Release|Any CPU
+		{8076DEF6-6BBF-42B0-BF64-8270B74B24ED}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8076DEF6-6BBF-42B0-BF64-8270B74B24ED}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8076DEF6-6BBF-42B0-BF64-8270B74B24ED}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8076DEF6-6BBF-42B0-BF64-8270B74B24ED}.Debug|x64.Build.0 = Debug|Any CPU
+		{8076DEF6-6BBF-42B0-BF64-8270B74B24ED}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8076DEF6-6BBF-42B0-BF64-8270B74B24ED}.Debug|x86.Build.0 = Debug|Any CPU
+		{8076DEF6-6BBF-42B0-BF64-8270B74B24ED}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8076DEF6-6BBF-42B0-BF64-8270B74B24ED}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8076DEF6-6BBF-42B0-BF64-8270B74B24ED}.Release|x64.ActiveCfg = Release|Any CPU
+		{8076DEF6-6BBF-42B0-BF64-8270B74B24ED}.Release|x64.Build.0 = Release|Any CPU
+		{8076DEF6-6BBF-42B0-BF64-8270B74B24ED}.Release|x86.ActiveCfg = Release|Any CPU
+		{8076DEF6-6BBF-42B0-BF64-8270B74B24ED}.Release|x86.Build.0 = Release|Any CPU
+		{951D73B6-FF0A-444C-B5F0-80E0E35A5B72}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{951D73B6-FF0A-444C-B5F0-80E0E35A5B72}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{951D73B6-FF0A-444C-B5F0-80E0E35A5B72}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{951D73B6-FF0A-444C-B5F0-80E0E35A5B72}.Debug|x64.Build.0 = Debug|Any CPU
+		{951D73B6-FF0A-444C-B5F0-80E0E35A5B72}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{951D73B6-FF0A-444C-B5F0-80E0E35A5B72}.Debug|x86.Build.0 = Debug|Any CPU
+		{951D73B6-FF0A-444C-B5F0-80E0E35A5B72}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{951D73B6-FF0A-444C-B5F0-80E0E35A5B72}.Release|Any CPU.Build.0 = Release|Any CPU
+		{951D73B6-FF0A-444C-B5F0-80E0E35A5B72}.Release|x64.ActiveCfg = Release|Any CPU
+		{951D73B6-FF0A-444C-B5F0-80E0E35A5B72}.Release|x64.Build.0 = Release|Any CPU
+		{951D73B6-FF0A-444C-B5F0-80E0E35A5B72}.Release|x86.ActiveCfg = Release|Any CPU
+		{951D73B6-FF0A-444C-B5F0-80E0E35A5B72}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tests/IntegrationTests/tests/msbuild/src/EmbeddedVersion/EmbeddedVersion.csproj
+++ b/tests/IntegrationTests/tests/msbuild/src/EmbeddedVersion/EmbeddedVersion.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Verlite.MsBuild" Version="0.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+</Project>

--- a/tests/IntegrationTests/tests/msbuild/src/EmbeddedVersion/Library.cs
+++ b/tests/IntegrationTests/tests/msbuild/src/EmbeddedVersion/Library.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace Package
+{
+	/// <summary>
+	/// Test library.
+	/// </summary>
+	public static class Library
+	{
+		/// <summary>
+		/// Test library function
+		/// </summary>
+		/// <returns>Hi.</returns>
+		public static string HelloTester()
+		{
+			return $"Hello, {Verlite.Version.Full}!";
+		}
+
+		/// <summary>
+		/// Compile time checks with no return as a compile error.
+		/// </summary>
+		public static class StaticAsserts
+		{
+			/// <summary>
+			/// Compile time check that the version is as expected.
+			/// </summary>
+			public static bool VersionIsExpected()
+			{
+				if (Verlite.Version.Full == "1.0.1-alpha.1")
+					return true;
+			}
+		}
+	}
+}

--- a/tests/IntegrationTests/tests/msbuild/src/EmbeddedVersionDisabled/EmbeddedVersionDisabled.csproj
+++ b/tests/IntegrationTests/tests/msbuild/src/EmbeddedVersionDisabled/EmbeddedVersionDisabled.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;netcoreapp3.1;net5.0</TargetFrameworks>
+    <VerliteEmbedVersion>false</VerliteEmbedVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Verlite.MsBuild" Version="0.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
+</Project>

--- a/tests/IntegrationTests/tests/msbuild/src/EmbeddedVersionDisabled/Library.cs
+++ b/tests/IntegrationTests/tests/msbuild/src/EmbeddedVersionDisabled/Library.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace Verlite
+{
+	internal static class Version
+	{
+		public const string Full = "World";
+	}
+}
+
+namespace Package
+{
+	/// <summary>
+	/// Test library.
+	/// </summary>
+	public static class Library
+	{
+		/// <summary>
+		/// Test library function
+		/// </summary>
+		/// <returns>Hi.</returns>
+		public static string HelloTester()
+		{
+			return $"Hello, {Verlite.Version.Full}!";
+		}
+	}
+
+	/// <summary>
+	/// Compile time checks with no return as a compile error.
+	/// </summary>
+	public static class StaticAsserts
+	{
+		/// <summary>
+		/// Compile time check that the version is as expected.
+		/// </summary>
+		public static bool VersionIsExpected()
+		{
+			if (Verlite.Version.Full == "World")
+				return true;
+		}
+	}
+}


### PR DESCRIPTION
Embeds version strings using a source generator into a simple static class.

These versions are not publicly exposed, and are internal static classes, ensuring no diamond dependency issues form.

- [x] Tests added
- [x] Linked issue if exists
- [x] Updated documentation
