### PR TITLE
Renamed DestinedVersion to CoreVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See [docs/VersionCalculation.md](docs/VersionCalculation.md) for further reading
 | Tags starting with this represent versions.                         | -t, --tag-prefix, VerliteTagPrefix                               | v       |
 | Disable the version prefix.                                         | VerliteDisableTagPrefix                                          | false   |
 | The default phase for the prerelease label                          | -d, --default-prerelease-phase, VerliteDefaultPrereleasePhase    | alpha   |
-| The minimum RTM version, i.e the destined version.                  | -m, --min-version, VerliteMinimumVersion                         | 0.1.0   |
+| The minimum RTM version that's a core version without a prerelease. | -m, --min-version, VerliteMinimumVersion                         | 0.1.0   |
 | The height for continuous deliverable auto heights should begin at. | -p, --prerelease-base-height, VerlitePrereleaseBaseHeight        | 1       |
 | Force the calculated version to be this version.                    | --version-override, VerliteVersionOverride                       |         |
 | Logging level.                                                      | --verbosity, VerliteVerbosity                                    | normal  |

--- a/src/Verlite.Core/PublicAPI.Unshipped.txt
+++ b/src/Verlite.Core/PublicAPI.Unshipped.txt
@@ -1,6 +1,7 @@
 #nullable enable
 Verlite.GitRepoInspector.Dispose() -> void
 Verlite.GitRepoInspector.Remote.get -> string!
+Verlite.SemVer.CoreVersion.get -> Verlite.SemVer
 Verlite.UnknownGitException
 Verlite.UnknownGitException.UnknownGitException(string! message) -> void
 Verlite.VersionCalculationOptions.Remote.get -> string!

--- a/src/Verlite.Core/SemVer.cs
+++ b/src/Verlite.Core/SemVer.cs
@@ -36,6 +36,13 @@ namespace Verlite
 		/// <summary>
 		/// The version without any prerelease or metadata, for which a prerelease would be working toward.
 		/// </summary>
+		public SemVer CoreVersion => new(Major, Minor, Patch);
+
+		/// <summary>
+		/// The version without any prerelease or metadata, for which a prerelease would be working toward.<br/>
+		/// Deprecated in favor of <see cref="CoreVersion"/>
+		/// </summary>
+		[Obsolete("Use CoreVersion")]
 		public SemVer DestinedVersion => new(Major, Minor, Patch);
 
 		/// <summary>

--- a/src/Verlite.Core/VersionCalculator.cs
+++ b/src/Verlite.Core/VersionCalculator.cs
@@ -39,7 +39,7 @@ namespace Verlite
 		/// <returns>The next version calculated from the input.</returns>
 		public static SemVer NextVersion(SemVer lastTag, VersionCalculationOptions options)
 		{
-			if (options.MinimumVersion > lastTag.DestinedVersion)
+			if (options.MinimumVersion > lastTag.CoreVersion)
 				return options.MinimumVersion;
 			else if (lastTag.Prerelease is not null)
 			{
@@ -73,8 +73,8 @@ namespace Verlite
 			bool directTag = height == 0;
 			if (directTag)
 			{
-				if (options.MinimumVersion > lastTag.Value.DestinedVersion)
-					throw new VersionCalculationException($"Direct tag ({lastTag.Value}) destined version ({lastTag.Value.DestinedVersion}) is below the minimum version ({options.MinimumVersion}).");
+				if (options.MinimumVersion > lastTag.Value.CoreVersion)
+					throw new VersionCalculationException($"Direct tag ({lastTag.Value}) destined version ({lastTag.Value.CoreVersion}) is below the minimum version ({options.MinimumVersion}).");
 
 				var directVersion = lastTag.Value;
 

--- a/tests/UnitTests/VersionTests.cs
+++ b/tests/UnitTests/VersionTests.cs
@@ -93,5 +93,22 @@ namespace UnitTests
 			(new SemVer(1, 0, 0, "alpha.1", "abc").CompareTo(new SemVer(1, 0, 0, "alpha.1", "def"))).Should().Be(0);
 			(new SemVer(1, 0, 0, "alpha.1", "abc").CompareTo(new SemVer(1, 0, 0, "alpha.2", "def"))).Should().Be(-1);
 		}
+
+		[Fact]
+		public void CoreVersionFunctions()
+		{
+			new SemVer(1, 0, 0, "alpha.1", "abc").CoreVersion.Should().Be(new SemVer(1, 0, 0));
+			new SemVer(1, 0, 0, null, "abc").CoreVersion.Should().Be(new SemVer(1, 0, 0));
+			new SemVer(2, 0, 0).CoreVersion.Should().Be(new SemVer(2, 0, 0));
+		}
+
+		[Fact]
+		[Obsolete("Function tested is obsolete.")]
+		public void DestinedVersionFunctions()
+		{
+			new SemVer(1, 0, 0, "alpha.1", "abc").DestinedVersion.Should().Be(new SemVer(1, 0, 0));
+			new SemVer(1, 0, 0, null, "abc").DestinedVersion.Should().Be(new SemVer(1, 0, 0));
+			new SemVer(2, 0, 0).DestinedVersion.Should().Be(new SemVer(2, 0, 0));
+		}
 	}
 }


### PR DESCRIPTION
I came across what I had called the "destined version" referred to as the "core version," and it makes a lot more sense to me,
therefore I'm adopting it,

The old variable has not been removed, but it has been marked as obsolete and will redirect to the new property.
