### PR TITLE
Minor fixes

### DIFF
--- a/.github/shared.yml
+++ b/.github/shared.yml
@@ -43,7 +43,7 @@ definitions:
   mutation-test: &mutation-test
     name: Mutation Test
     run: |
-      dotnet tool install --global dotnet-stryker
+      dotnet tool install --global dotnet-stryker --version 1.5.3
       cd tests/UnitTests
       if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
         dotnet stryker --reporter html --reporter dashboard --reporter progress --version master

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -77,7 +77,7 @@ jobs:
 
     - name: Mutation Test
       run: |
-        dotnet tool install --global dotnet-stryker
+        dotnet tool install --global dotnet-stryker --version 1.5.3
         cd tests/UnitTests
         if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
           dotnet stryker --reporter html --reporter dashboard --reporter progress --version master

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -77,7 +77,7 @@ jobs:
 
     - name: Mutation Test
       run: |
-        dotnet tool install --global dotnet-stryker
+        dotnet tool install --global dotnet-stryker --version 1.5.3
         cd tests/UnitTests
         if [[ "$GITHUB_REF" == "refs/heads/master" ]]; then
           dotnet stryker --reporter html --reporter dashboard --reporter progress --version master

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,7 +46,7 @@
     <MinVerTagPrefix>v</MinVerTagPrefix>
     <!-- delete/set to patch the line below once almost out of v0.x.y (preferably once on a beta or rc). -->
     <MinVerAutoIncrement>patch</MinVerAutoIncrement>
-    <MinVerMinimumMajorMinor>2.1</MinVerMinimumMajorMinor>
+    <MinVerMinimumMajorMinor>2.2</MinVerMinimumMajorMinor>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.0.0">

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ See [docs/VersionCalculation.md](docs/VersionCalculation.md) for further reading
 | Set the build data to this value.                                   | -b, --build-metadata, VerliteBuildMetadata                       |         |
 | Part of the version to print.                                       | -s, --show                                                       | all     |
 | Automatically fetch commits and a tag for shallow clones.           | --auto-fetch                                                     | false   |
+| Create a lightweight tag instead of fetching the remote's.              | --enable-lightweight-tags                                        | false   |
 | Set which version part should be bumped after an RTM release.       | -a, --auto-increment, VerliteAutoIncrement                       | patch   |
 | A command to test whether a tag should be ignored via exit code.    | -f, --filter-tags, VerliteFilterTags                             |         |
 | The remote endpoint to use when fetching tags and commits.          | -r, --remote, VerliteRemote                                      | origin  |

--- a/src/Verlite.CLI/Program.cs
+++ b/src/Verlite.CLI/Program.cs
@@ -81,6 +81,10 @@ namespace Verlite.CLI
 					aliases: new[] { "--auto-fetch" },
 					getDefaultValue: () => false,
 					description: "Automatically fetch commits from a shallow repository until a version tag is encountered."),
+				new Option<bool>(
+					aliases: new[] { "--fetch-lightweight-tags" },
+					getDefaultValue: () => false,
+					description: "Create a lightweight tag instead of fetching the remote's."),
 				new Option<AutoIncrement>(
 					aliases: new[] { "--auto-increment", "-a" },
 					isDefault: true,
@@ -109,6 +113,7 @@ namespace Verlite.CLI
 			string? buildMetadata,
 			Show show,
 			bool autoFetch,
+			bool fetchLightweightTags,
 			AutoIncrement autoIncrement,
 			string filterTags,
 			string remote,
@@ -140,6 +145,7 @@ namespace Verlite.CLI
 				{
 					using var repo = await GitRepoInspector.FromPath(sourceDirectory, opts.Remote, log, commandRunner);
 					repo.CanDeepen = autoFetch;
+					repo.EnableLightweightTags = fetchLightweightTags;
 
 					ITagFilter? tagFilter = null;
 					if (!string.IsNullOrWhiteSpace(filterTags))

--- a/src/Verlite.CLI/Program.cs
+++ b/src/Verlite.CLI/Program.cs
@@ -169,18 +169,18 @@ namespace Verlite.CLI
 			}
 			catch (GitMissingOrNotGitRepoException)
 			{
-				Console.Error.WriteLine("Input is not a git repo or git not installed.");
+				await Console.Error.WriteLineAsync("Input is not a git repo or git not installed.");
 				Environment.Exit(1);
 			}
 			catch (AutoDeepenException ex)
 			{
-				Console.Error.WriteLine(ex.Message);
+				await Console.Error.WriteLineAsync(ex.Message);
 				Environment.Exit(1);
 			}
 			catch (RepoTooShallowException ex)
 			{
-				Console.Error.WriteLine(ex.Message);
-				Console.Error.WriteLine("For CI/CD, use `verlite --auto-fetch`");
+				await Console.Error.WriteLineAsync(ex.Message);
+				await Console.Error.WriteLineAsync("For CI/CD, use `verlite --auto-fetch`");
 				Environment.Exit(1);
 			}
 		}

--- a/src/Verlite.Core/GitRepoInspector.cs
+++ b/src/Verlite.Core/GitRepoInspector.cs
@@ -72,6 +72,10 @@ namespace Verlite
 		/// </summary>
 		public bool CanDeepen { get; set; }
 		/// <summary>
+		/// Enable shortcutting git fetch to eliminate potentially problematic git fetches.
+		/// </summary>
+		public bool EnableLightweightTags { get; set; }
+		/// <summary>
 		/// The root of the repository.
 		/// </summary>
 		public string Root { get; }
@@ -280,6 +284,7 @@ namespace Verlite
 		}
 
 		private bool DeepenFromCommitSupported { get; set; } = true;
+
 		private async Task Deepen()
 		{
 			var probe = await ProbeDepth();
@@ -427,6 +432,12 @@ namespace Verlite
 		/// <inheritdoc/>
 		public async Task FetchTag(Tag tag, string remote)
 		{
+			if (EnableLightweightTags)
+			{
+				await Git("tag", "--no-sign", tag.Name, tag.PointsTo.Id);
+				return;
+			}
+
 			var probe = await ProbeDepth();
 
 			Log?.Verbose($"FetchTag({tag}, {remote})");

--- a/src/Verlite.Core/GitRepoInspector.cs
+++ b/src/Verlite.Core/GitRepoInspector.cs
@@ -176,12 +176,22 @@ namespace Verlite
 						throw new UnknownGitException($"The git cat-file process returned unexpected output: {result}");
 				}
 
-				await cin.WriteLineAsync(id);
-				string line = await cout.ReadLineAsync();
-				string[] response = line.Split(' ');
+				using var cts2 = new CancellationTokenSource();
+				var timeout2 = Task.Delay(10_000, cts2.Token);
 
 				Log?.Verbatim($"git cat-file < {id}");
+				if (await Task.WhenAny(cin.WriteLineAsync(id), timeout2) == timeout2)
+					throw new UnknownGitException("The git cat-file process write timed out.");
+
+				var readLineTask = cout.ReadLineAsync();
+				if (await Task.WhenAny(readLineTask, timeout2) == timeout2)
+					throw new UnknownGitException("The git cat-file process read timed out.");
+				cts2.Cancel();
+
+				string line = await readLineTask;
 				Log?.Verbatim($"git cat-file > {line}");
+				string[] response = line.Split(' ');
+
 
 				if (response[0] != id)
 					throw new UnknownGitException("The returned blob hash did not match.");

--- a/src/Verlite.Core/HeightCalculator.cs
+++ b/src/Verlite.Core/HeightCalculator.cs
@@ -89,8 +89,7 @@ namespace Verlite
 		/// </summary>
 		/// <param name="repo">The repo to walk.</param>
 		/// <param name="tagPrefix">What version tags are prefixed with.</param>
-		/// <param name="queryRemoteTags">Whether to query local or local and remote tags.</param>
-		/// <param name="fetchTags">Whether to fetch tags we don't yet have locally.</param>
+		/// <param name="queryRemoteTags">Whether to query local or local and remote tags, will not be fetched.</param>
 		/// <param name="log">The log to output verbose diagnostics to.</param>
 		/// <param name="tagFilter">A filter to test tags against. A value of <c>null</c> means do not filter.</param>
 		/// <returns>A task containing the height, and, if found, the tagged version.</returns>

--- a/src/Verlite.Core/PublicAPI.Unshipped.txt
+++ b/src/Verlite.Core/PublicAPI.Unshipped.txt
@@ -1,7 +1,10 @@
 #nullable enable
 Verlite.GitRepoInspector.Dispose() -> void
+Verlite.GitRepoInspector.EnableLightweightTags.get -> bool
+Verlite.GitRepoInspector.EnableLightweightTags.set -> void
 Verlite.GitRepoInspector.Remote.get -> string!
 Verlite.SemVer.CoreVersion.get -> Verlite.SemVer
+Verlite.TagContainer.ContainsTag(Verlite.Tag tag) -> bool
 Verlite.UnknownGitException
 Verlite.UnknownGitException.UnknownGitException(string! message) -> void
 Verlite.VersionCalculationOptions.Remote.get -> string!

--- a/src/Verlite.Core/PublicAPI.Unshipped.txt
+++ b/src/Verlite.Core/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 #nullable enable
+static Verlite.HeightCalculator.FromRepository(Verlite.IRepoInspector! repo, string! tagPrefix, bool queryRemoteTags, bool fetchTags, Verlite.ILogger? log, Verlite.ITagFilter? tagFilter) -> System.Threading.Tasks.Task<(int height, Verlite.TaggedVersion?)>!
 Verlite.GitRepoInspector.Dispose() -> void
 Verlite.GitRepoInspector.EnableLightweightTags.get -> bool
 Verlite.GitRepoInspector.EnableLightweightTags.set -> void

--- a/src/Verlite.Core/TagContainer.cs
+++ b/src/Verlite.Core/TagContainer.cs
@@ -34,6 +34,11 @@ namespace Verlite
 			return ret;
 		}
 
+		public bool ContainsTag(Tag tag)
+		{
+			return Tags.Contains(tag);
+		}
+
 		/// <summary>
 		/// Gets the enumerator for iterating over the collection.
 		/// </summary>

--- a/src/Verlite.Core/TagContainer.cs
+++ b/src/Verlite.Core/TagContainer.cs
@@ -34,6 +34,11 @@ namespace Verlite
 			return ret;
 		}
 
+		/// <summary>
+		/// Check if the container contains this exact tag.
+		/// </summary>
+		/// <param name="tag">The tag to check.</param>
+		/// <returns>If it was found.</returns>
 		public bool ContainsTag(Tag tag)
 		{
 			return Tags.Contains(tag);

--- a/src/Verlite.Core/VersionCalculator.cs
+++ b/src/Verlite.Core/VersionCalculator.cs
@@ -116,20 +116,8 @@ namespace Verlite
 				queryRemoteTags: options.QueryRemoteTags,
 				log: log,
 				tagFilter: tagFilter);
-			var version = FromTagInfomation(lastTagVer?.Version, options, height);
 
-			if (lastTagVer is not null && options.QueryRemoteTags)
-			{
-				var localTag = (await repo.GetTags(QueryTarget.Local))
-					.Where(x => x == lastTagVer.Tag);
-				if (!localTag.Any())
-				{
-					log?.Normal("Local repo missing version tag, fetching.");
-					await repo.FetchTag(lastTagVer.Tag);
-				}
-			}
-
-			return version;
+			return FromTagInfomation(lastTagVer?.Version, options, height);
 		}
 	}
 }

--- a/src/Verlite.Core/VersionCalculator.cs
+++ b/src/Verlite.Core/VersionCalculator.cs
@@ -114,6 +114,7 @@ namespace Verlite
 				repo: repo,
 				tagPrefix: options.TagPrefix,
 				queryRemoteTags: options.QueryRemoteTags,
+				fetchTags: options.QueryRemoteTags,
 				log: log,
 				tagFilter: tagFilter);
 

--- a/tests/UnitTests/GitRepoInspectorTests.cs
+++ b/tests/UnitTests/GitRepoInspectorTests.cs
@@ -513,7 +513,7 @@ namespace UnitTests
 
 			// forcibly desync the git catfile process
 			Assert.NotNull(repo.CatFileProcess);
-			repo.CatFileProcess!.StandardInput.WriteLine(head.Value);
+			await repo.CatFileProcess!.StandardInput.WriteLineAsync(head.Value.Id);
 
 			// attempt to read a non-cached parent
 			await Assert.ThrowsAsync<UnknownGitException>(() => repo.GetParents(parents[0]));

--- a/tests/UnitTests/GitRepoInspectorTests.cs
+++ b/tests/UnitTests/GitRepoInspectorTests.cs
@@ -255,6 +255,35 @@ namespace UnitTests
 		}
 
 		[Fact]
+		public async Task CanCreateLightweightTags()
+		{
+			await TestRepo.Git("init");
+			await TestRepo.Git("commit", "--allow-empty", "-m", "first");
+			await TestRepo.Git("tag", "tag-one");
+			await TestRepo.Git("commit", "--allow-empty", "-m", "second");
+			await TestRepo.Git("tag", "tag-two");
+
+			using var clone = new GitTestDirectory();
+			await clone.Git("clone", TestRepo.RootPath, ".", "--no-tags");
+
+			using var repo = await clone.MakeInspector();
+			repo.EnableLightweightTags = true;
+			var remoteTags = await repo.GetTags(QueryTarget.Remote);
+
+			var firstTags = remoteTags.FindCommitTags(new Commit("b2000fc1f1d2e5f816cfa51a4ad8764048f22f0a"));
+			firstTags.Should().ContainSingle();
+			var firstTag = firstTags[0];
+
+			await repo.FetchTag(firstTag);
+
+			var localTags = await repo.GetTags(QueryTarget.Local);
+			localTags.Should().Contain(new Tag[]
+			{
+				firstTag,
+			});
+		}
+
+		[Fact]
 		public async Task ShallowCloneStillQueriesTags()
 		{
 			await TestRepo.Git("init");

--- a/tests/UnitTests/HeightCalculationTests.cs
+++ b/tests/UnitTests/HeightCalculationTests.cs
@@ -23,7 +23,7 @@ namespace UnitTests
 				new("commit_c"),
 			});
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", true);
+			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			tag.Should().NotBeNull();
 			SDebug.Assert(tag is not null);
@@ -39,7 +39,7 @@ namespace UnitTests
 		{
 			var repo = new MockRepoInspector(Array.Empty<MockRepoCommit>());
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", true);
+			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			tag.Should().BeNull();
 			height.Should().Be(1);
@@ -53,7 +53,7 @@ namespace UnitTests
 				new("commit_a"),
 			});
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", true);
+			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			tag.Should().BeNull();
 			height.Should().Be(1);
@@ -73,7 +73,7 @@ namespace UnitTests
 
 			var repo = new MockRepoInspector(gtor, master);
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", true);
+			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			tag.Should().BeNull();
 			height.Should().Be(2);
@@ -93,7 +93,7 @@ namespace UnitTests
 
 			var repo = new MockRepoInspector(gtor, master);
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", true);
+			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			tag.Should().BeNull();
 			height.Should().Be(2);
@@ -114,7 +114,7 @@ namespace UnitTests
 
 			var repo = new MockRepoInspector(gtor, master);
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", true);
+			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			Assert.NotNull(tag);
 			tag!.Tag.Name.Should().Be("v1.0.0+master");
@@ -136,7 +136,7 @@ namespace UnitTests
 
 			var repo = new MockRepoInspector(gtor, feature);
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", true);
+			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			Assert.NotNull(tag);
 			tag!.Tag.Name.Should().Be("v2.0.0");
@@ -159,7 +159,7 @@ namespace UnitTests
 
 			var repo = new MockRepoInspector(gtor, master);
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", true);
+			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			Assert.NotNull(tag);
 			tag!.Tag.Name.Should().Be("v2.0.0");
@@ -182,7 +182,7 @@ namespace UnitTests
 
 			var repo = new MockRepoInspector(gtor, feature);
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", true);
+			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			Assert.NotNull(tag);
 			tag!.Tag.Name.Should().Be("v2.0.0");
@@ -206,7 +206,7 @@ namespace UnitTests
 
 			var repo = new MockRepoInspector(gtor, master);
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", true);
+			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			Assert.NotNull(tag);
 			tag!.Tag.Name.Should().Be("v1.0.0");
@@ -228,7 +228,7 @@ namespace UnitTests
 
 			var repo = new MockRepoInspector(gtor, master);
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", true);
+			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			Assert.NotNull(tag);
 			tag!.Tag.Name.Should().Be("v1.0.0");
@@ -245,7 +245,7 @@ namespace UnitTests
 				new("commit_c"),
 			});
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", true);
+			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			tag.Should().BeNull();
 			height.Should().Be(3);
@@ -261,7 +261,7 @@ namespace UnitTests
 				new("commit_c"),
 			});
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", true);
+			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			tag.Should().BeNull();
 			height.Should().Be(3);
@@ -278,7 +278,7 @@ namespace UnitTests
 				new("commit_c") { Tags = new[]{ "v" } },
 			});
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", true);
+			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			tag.Should().BeNull();
 			height.Should().Be(3);
@@ -294,7 +294,7 @@ namespace UnitTests
 				new("commit_c"),
 			});
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", true);
+			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			tag.Should().NotBeNull();
 			SDebug.Assert(tag is not null);
@@ -315,7 +315,7 @@ namespace UnitTests
 				new("commit_c"),
 			});
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", true);
+			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			tag.Should().NotBeNull();
 			SDebug.Assert(tag is not null);
@@ -337,7 +337,9 @@ namespace UnitTests
 				new("commit_c") { Tags = new[]{ "v1.0.0-alpha.1" } },
 			});
 
-			(_, _) = await HeightCalculator.FromRepository(repo, "v", true);
+#pragma warning disable CS0618 // intentional use of deprecated function
+			(_, _) = await HeightCalculator.FromRepository(repo, "v", true, null, null);
+#pragma warning restore CS0618
 
 			var tags = await (repo as IRepoInspector).GetTags(QueryTarget.Local);
 			tags.FindCommitTags(new("commit_c")).Should().BeEquivalentTo(Array.Empty<Tag>());
@@ -358,7 +360,7 @@ namespace UnitTests
 				new("commit_d"),
 			});
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, prefix, true);
+			var (height, tag) = await HeightCalculator.FromRepository(repo, prefix, queryRemoteTags: true, fetchTags: false, null, null);
 
 			height.Should().Be(resultHeight);
 
@@ -393,7 +395,7 @@ namespace UnitTests
 			var filter = new MockTagFilter();
 			filter.BlockTags.Add("v1.0.0");
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", true, null, filter);
+			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, filter);
 
 			tag.Should().NotBeNull();
 			SDebug.Assert(tag is not null);
@@ -416,7 +418,7 @@ namespace UnitTests
 			var filter = new MockTagFilter();
 			filter.BlockTags.Add("v1.0.0");
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", true, null, filter);
+			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, filter);
 
 			tag.Should().NotBeNull();
 			SDebug.Assert(tag is not null);


### PR DESCRIPTION
- Fetch all tags, not just the final tag
- Add ability to create lightweight tags instead of fetching the remote's.
- Moved the fetching into `FromRepository`.
- Deprecated old usage of `FromRepository`.
- Pin stryker to a version that supports dotnet 5
- Add a timeout when talking to git