### PR TITLE
Add additional outputs

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -46,7 +46,7 @@
     <MinVerTagPrefix>v</MinVerTagPrefix>
     <!-- delete/set to patch the line below once almost out of v0.x.y (preferably once on a beta or rc). -->
     <MinVerAutoIncrement>patch</MinVerAutoIncrement>
-    <MinVerMinimumMajorMinor>2.2</MinVerMinimumMajorMinor>
+    <MinVerMinimumMajorMinor>2.3</MinVerMinimumMajorMinor>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MinVer" Version="4.0.0">

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ See [docs/VersionCalculation.md](docs/VersionCalculation.md) for further reading
 | Set the build data to this value.                                   | -b, --build-metadata, VerliteBuildMetadata                       |         |
 | Part of the version to print.                                       | -s, --show                                                       | all     |
 | Automatically fetch commits and a tag for shallow clones.           | --auto-fetch                                                     | false   |
-| Create a lightweight tag instead of fetching the remote's.              | --enable-lightweight-tags                                        | false   |
+| Create a lightweight tag instead of fetching the remote's.          | --enable-lightweight-tags                                        | false   |
 | Set which version part should be bumped after an RTM release.       | -a, --auto-increment, VerliteAutoIncrement                       | patch   |
 | A command to test whether a tag should be ignored via exit code.    | -f, --filter-tags, VerliteFilterTags                             |         |
 | The remote endpoint to use when fetching tags and commits.          | -r, --remote, VerliteRemote                                      | origin  |
@@ -243,6 +243,8 @@ namespace Verlite
 		public const string Patch;
 		public const string Prerelease;
 		public const string BuildMetadata;
+		public const string Commit;
+		public const string Height;
 	}
 }
 ```

--- a/src/Verlite.CLI/JsonOutput.cs
+++ b/src/Verlite.CLI/JsonOutput.cs
@@ -1,0 +1,67 @@
+using System.Globalization;
+using System.Text;
+
+namespace Verlite.CLI
+{
+	internal static class JsonOutput
+	{
+		public static string GenerateOutput(
+			SemVer version,
+			Commit? commit,
+			TaggedVersion? lastTag,
+			int? height)
+		{
+			var sb = new StringBuilder();
+			sb.AppendLine("{");
+			sb.AppendString(1, "commit", commit?.Id);
+			sb.AppendString(1, "full", version.ToString());
+			sb.AppendInteger(1, "major", version.Major);
+			sb.AppendInteger(1, "minor", version.Minor);
+			sb.AppendInteger(1, "patch", version.Patch);
+			sb.AppendString(1, "prerelease", version.Prerelease);
+			sb.AppendString(1, "meta", version.BuildMetadata);
+			sb.AppendInteger(1, "height", height);
+			if (lastTag is null)
+			{
+				sb.AppendLine("\t" + @"""lastTag"": null");
+			}
+			else
+			{
+				sb.AppendLine("\t" + @"""lastTag"": {");
+				sb.AppendString(2, "tag", lastTag.Tag.Name);
+				sb.AppendString(2, "commit", lastTag.Tag.PointsTo.Id);
+				sb.AppendString(2, "full", lastTag.Version.ToString());
+				sb.AppendInteger(2, "major", lastTag.Version.Major);
+				sb.AppendInteger(2, "minor", lastTag.Version.Minor);
+				sb.AppendInteger(2, "patch", lastTag.Version.Patch);
+				sb.AppendString(2, "prerelease", lastTag.Version.Prerelease);
+				sb.AppendString(2, "meta", lastTag.Version.BuildMetadata, final: true);
+				sb.AppendLine("\t}");
+			}
+			sb.AppendLine("}");
+
+			return sb.ToString();
+		}
+
+		private static void AppendString(this StringBuilder sb, int indentation, string key, string? value, bool final = false)
+		{
+			value = value is null ? "null" : $@"""{System.Web.HttpUtility.JavaScriptStringEncode(value)}""";
+			sb.Append(new string('\t', indentation));
+			sb.Append($@"""{key}"": {value}");
+			if (final)
+				sb.AppendLine("");
+			else
+				sb.AppendLine(",");
+		}
+		private static void AppendInteger(this StringBuilder sb, int indentation, string key, int? value, bool final = false)
+		{
+			var valuestr = value is null ? "null" : value.Value.ToString(CultureInfo.InvariantCulture);
+			sb.Append(new string('\t', indentation));
+			sb.Append($@"""{key}"": ""{valuestr}""");
+			if (final)
+				sb.AppendLine("");
+			else
+				sb.AppendLine(",");
+		}
+	}
+}

--- a/src/Verlite.CLI/Show.cs
+++ b/src/Verlite.CLI/Show.cs
@@ -11,6 +11,8 @@ namespace Verlite.CLI
 		patch = 3,
 		prerelease = 4,
 		metadata = 5,
+		height = 6,
+		json = 7,
 	}
 	internal static partial class Parsers
 	{
@@ -34,6 +36,8 @@ namespace Verlite.CLI
 				"PATCH"      => Show.patch,
 				"PRERELEASE" => Show.prerelease,
 				"METADATA"   => Show.metadata,
+				"HEIGHT"     => Show.height,
+				"JSON"       => Show.json,
 				_ => invalid(),
 			};
 		}

--- a/src/Verlite.Core/PublicAPI.Unshipped.txt
+++ b/src/Verlite.Core/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+static Verlite.VersionCalculator.FromRepository2(Verlite.IRepoInspector! repo, Verlite.VersionCalculationOptions! options, Verlite.ILogger? log, Verlite.ITagFilter? tagFilter) -> System.Threading.Tasks.Task<(Verlite.SemVer version, Verlite.TaggedVersion? lastTag, int? height)>!

--- a/src/Verlite.Core/VersionCalculator.cs
+++ b/src/Verlite.Core/VersionCalculator.cs
@@ -104,6 +104,7 @@ namespace Verlite
 		/// <param name="log">A log for diagnostics.</param>
 		/// <param name="tagFilter">A filter to ignore tags. When <c>null</c> no filter is used.</param>
 		/// <returns>The version for the state of the repository.</returns>
+		[Obsolete("Use FromRepository2()")]
 		public static async Task<SemVer> FromRepository(
 			IRepoInspector repo,
 			VersionCalculationOptions options,
@@ -119,6 +120,35 @@ namespace Verlite
 				tagFilter: tagFilter);
 
 			return FromTagInfomation(lastTagVer?.Version, options, height);
+		}
+
+		/// <summary>
+		/// Calculate the next version from a repository.
+		/// </summary>
+		/// <param name="repo">The repo to use.</param>
+		/// <param name="options">The options.</param>
+		/// <param name="log">A log for diagnostics.</param>
+		/// <param name="tagFilter">A filter to ignore tags. When <c>null</c> no filter is used.</param>
+		/// <returns>The version for the state of the repository, and the associated tag information.</returns>
+		public static async Task<(SemVer version, TaggedVersion? lastTag, int? height)> FromRepository2(
+			IRepoInspector repo,
+			VersionCalculationOptions options,
+			ILogger? log,
+			ITagFilter? tagFilter)
+		{
+			if (options.VersionOverride.HasValue)
+				return (options.VersionOverride.Value, null, null);
+
+			var (height, lastTag) = await HeightCalculator.FromRepository(
+				repo: repo,
+				tagPrefix: options.TagPrefix,
+				queryRemoteTags: options.QueryRemoteTags,
+				fetchTags: options.QueryRemoteTags,
+				log: log,
+				tagFilter: tagFilter);
+
+			var version = FromTagInfomation(lastTag?.Version, options, height);
+			return (version, lastTag, height);
 		}
 	}
 }

--- a/src/Verlite.MsBuild/GetVersionTask.cs
+++ b/src/Verlite.MsBuild/GetVersionTask.cs
@@ -109,6 +109,7 @@ namespace Verlite.MsBuild
 
 			var version = opts.VersionOverride ?? new SemVer();
 			var commit = string.Empty;
+			var height = string.Empty;
 			if (opts.VersionOverride is null)
 			{
 				using var repo = await GitRepoInspector.FromPath(ProjectDirectory, opts.Remote, log, commandRunner);
@@ -117,8 +118,10 @@ namespace Verlite.MsBuild
 				if (!string.IsNullOrWhiteSpace(FilterTags))
 					tagFilter = new CommandTagFilter(commandRunner, log, FilterTags, ProjectDirectory);
 
-				version = await VersionCalculator.FromRepository(repo, opts, log, tagFilter);
+				int? heightInt;
+				(version, _, heightInt) = await VersionCalculator.FromRepository2(repo, opts, log, tagFilter);
 				commit = (await repo.GetHead())?.Id ?? string.Empty;
+				height = heightInt?.ToString(CultureInfo.InvariantCulture) ?? string.Empty;
 			}
 
 			Version = version.ToString();
@@ -128,6 +131,7 @@ namespace Verlite.MsBuild
 			VersionPrerelease = version.Prerelease ?? string.Empty;
 			VersionBuildMetadata = version.BuildMetadata ?? string.Empty;
 			Commit = commit;
+			Height = height;
 			
 			return true;
 		}
@@ -138,5 +142,6 @@ namespace Verlite.MsBuild
 		[Output] public string VersionPrerelease { get; private set; } = "";
 		[Output] public string VersionBuildMetadata { get; private set; } = "";
 		[Output] public string Commit { get; private set; } = "";
+		[Output] public string Height { get; private set; } = "";
 	}
 }

--- a/src/Verlite.MsBuild/VersionEmbedGenerator.cs
+++ b/src/Verlite.MsBuild/VersionEmbedGenerator.cs
@@ -24,6 +24,7 @@ namespace Verlite
 			context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.VerlitePrerelease", out var prerelease);
 			context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.VerliteBuildMetadata", out var meta);
 			context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.VerliteCommit", out var commit);
+			context.AnalyzerConfigOptions.GlobalOptions.TryGetValue("build_property.VerliteHeight", out var height);
 
 			version ??= string.Empty;
 			major ??= string.Empty;
@@ -32,6 +33,7 @@ namespace Verlite
 			prerelease ??= string.Empty;
 			meta ??= string.Empty;
 			commit ??= string.Empty;
+			height ??= string.Empty;
 
 			var coreVersion = string.IsNullOrEmpty(version) ? string.Empty : $"{major}.{minor}.{patch}";
 
@@ -54,6 +56,7 @@ namespace Verlite
 		public const string Prerelease = ""{prerelease}"";
 		public const string BuildMetadata = ""{meta}"";
 		public const string Commit = ""{commit}"";
+		public const string Height = ""{height}"";
 	}}
 }}
 ";

--- a/src/Verlite.MsBuild/build/Verlite.MsBuild.targets
+++ b/src/Verlite.MsBuild/build/Verlite.MsBuild.targets
@@ -28,6 +28,7 @@ This file has been modified by Ashleigh Adams and adapted for Verlite -->
     <CompilerVisibleProperty Include="VerlitePrerelease" />
     <CompilerVisibleProperty Include="VerliteBuildMetadata" />
     <CompilerVisibleProperty Include="VerliteCommit" />
+    <CompilerVisibleProperty Include="VerliteHeight" />
   </ItemGroup>
 
   <PropertyGroup>
@@ -77,6 +78,7 @@ This file has been modified by Ashleigh Adams and adapted for Verlite -->
       <Output TaskParameter="VersionPrerelease" PropertyName="VerlitePrerelease" />
       <Output TaskParameter="VersionBuildMetadata" PropertyName="VerliteBuildMetadata" />
       <Output TaskParameter="Commit" PropertyName="VerliteCommit" />
+      <Output TaskParameter="Height" PropertyName="VerliteHeight" />
     </Verlite.MsBuild.GetVersionTask>
 
     <PropertyGroup>


### PR DESCRIPTION
- CLI: Added ability to output json structs and height
- MsBuild: Enabled access to commit height
- Core: Added new `FromRepository2()` which returns more information

Note: No additional json library is used to avoid issues surrounding multiple versions of libraries being loaded at once, future AoT, and explicitness.

<!-- Please read CONTRIBUTING.md -->

High level of what was changed, possibly include why this approach was taken.

Are there any concerns or areas to be aware of regarding the approach taken or areas changed?

- [x] Tests added
- [x] Linked issue if exists
- [x] Updated documentation
