### PR TITLE
Fix lightweight tags when the repo is exactly 1 commit too shallow

### DIFF
--- a/src/Verlite.Core/GitRepoInspector.cs
+++ b/src/Verlite.Core/GitRepoInspector.cs
@@ -493,6 +493,11 @@ namespace Verlite
 		{
 			if (EnableLightweightTags)
 			{
+				// make sure we actually have the commit object downloaded, else we can't tag it
+				// this may happen when the clone is exactly 1 commit too shallow, and this method,
+				// if using auto-fetch, we de-shallow appropriately
+				_ = await GetCommitObject(tag.PointsTo);
+				
 				await Git("tag", "--no-sign", tag.Name, tag.PointsTo.Id);
 				return;
 			}


### PR DESCRIPTION
By fetching the commit object when we attempt to create a lightweight tag, the automatic de-shallowing mechanism will take over and ensure the commit is actually downloaded, and can subsequently then have a lightweight tag be created.

<!-- Please read CONTRIBUTING.md -->

High level of what was changed, possibly include why this approach was taken.

Are there any concerns or areas to be aware of regarding the approach taken or areas changed?

- [ ] ~~Tests added~~
- [x] Linked issue if exists
- [ ] ~~Updated documentation~~
