### PR TITLE
Allow querying revisions

### DIFF
--- a/src/Verlite.Core/IRepoInspector.cs
+++ b/src/Verlite.Core/IRepoInspector.cs
@@ -70,6 +70,12 @@ namespace Verlite
 		/// <returns>A task containing the commit, or <c>null</c> if there is none.</returns>
 		Task<Commit?> GetHead();
 		/// <summary>
+		/// Parse a revision to find the commit it points to.
+		/// </summary>
+		/// <param name="revision">The revision to parse.</param>
+		/// <returns>Returns the commit if found, else returns <c>null</c> when <paramref name="revision"/> is a head spec, else throws.</returns>
+		Task<Commit?> ParseRevision(string revision);
+		/// <summary>
 		/// Gets all parents of the specified commit.
 		/// </summary>
 		/// <param name="commit">The commit.</param>

--- a/src/Verlite.Core/PublicAPI.Unshipped.txt
+++ b/src/Verlite.Core/PublicAPI.Unshipped.txt
@@ -1,2 +1,4 @@
 #nullable enable
+static Verlite.HeightCalculator.FromRepository2(Verlite.IRepoInspector! repo, Verlite.Commit? commit, string! tagPrefix, bool queryRemoteTags, bool fetchTags, Verlite.ILogger? log, Verlite.ITagFilter? tagFilter) -> System.Threading.Tasks.Task<(int height, Verlite.TaggedVersion?)>!
 static Verlite.VersionCalculator.FromRepository2(Verlite.IRepoInspector! repo, Verlite.VersionCalculationOptions! options, Verlite.ILogger? log, Verlite.ITagFilter? tagFilter) -> System.Threading.Tasks.Task<(Verlite.SemVer version, Verlite.TaggedVersion? lastTag, int? height)>!
+Verlite.IRepoInspector.ParseRevision(string! revision) -> System.Threading.Tasks.Task<Verlite.Commit?>!

--- a/tests/UnitTests/HeightCalculationTests.cs
+++ b/tests/UnitTests/HeightCalculationTests.cs
@@ -23,7 +23,7 @@ namespace UnitTests
 				new("commit_c"),
 			});
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
+			var (height, tag) = await HeightCalculator.FromRepository2(repo, repo.Head, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			tag.Should().NotBeNull();
 			SDebug.Assert(tag is not null);
@@ -39,7 +39,7 @@ namespace UnitTests
 		{
 			var repo = new MockRepoInspector(Array.Empty<MockRepoCommit>());
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
+			var (height, tag) = await HeightCalculator.FromRepository2(repo, repo.Head, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			tag.Should().BeNull();
 			height.Should().Be(1);
@@ -53,7 +53,7 @@ namespace UnitTests
 				new("commit_a"),
 			});
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
+			var (height, tag) = await HeightCalculator.FromRepository2(repo, repo.Head, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			tag.Should().BeNull();
 			height.Should().Be(1);
@@ -73,7 +73,7 @@ namespace UnitTests
 
 			var repo = new MockRepoInspector(gtor, master);
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
+			var (height, tag) = await HeightCalculator.FromRepository2(repo, repo.Head, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			tag.Should().BeNull();
 			height.Should().Be(2);
@@ -93,7 +93,7 @@ namespace UnitTests
 
 			var repo = new MockRepoInspector(gtor, master);
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
+			var (height, tag) = await HeightCalculator.FromRepository2(repo, repo.Head, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			tag.Should().BeNull();
 			height.Should().Be(2);
@@ -114,7 +114,7 @@ namespace UnitTests
 
 			var repo = new MockRepoInspector(gtor, master);
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
+			var (height, tag) = await HeightCalculator.FromRepository2(repo, repo.Head, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			Assert.NotNull(tag);
 			tag!.Tag.Name.Should().Be("v1.0.0+master");
@@ -136,7 +136,7 @@ namespace UnitTests
 
 			var repo = new MockRepoInspector(gtor, feature);
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
+			var (height, tag) = await HeightCalculator.FromRepository2(repo, repo.Head, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			Assert.NotNull(tag);
 			tag!.Tag.Name.Should().Be("v2.0.0");
@@ -159,7 +159,7 @@ namespace UnitTests
 
 			var repo = new MockRepoInspector(gtor, master);
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
+			var (height, tag) = await HeightCalculator.FromRepository2(repo, repo.Head, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			Assert.NotNull(tag);
 			tag!.Tag.Name.Should().Be("v2.0.0");
@@ -182,7 +182,7 @@ namespace UnitTests
 
 			var repo = new MockRepoInspector(gtor, feature);
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
+			var (height, tag) = await HeightCalculator.FromRepository2(repo, repo.Head, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			Assert.NotNull(tag);
 			tag!.Tag.Name.Should().Be("v2.0.0");
@@ -206,7 +206,7 @@ namespace UnitTests
 
 			var repo = new MockRepoInspector(gtor, master);
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
+			var (height, tag) = await HeightCalculator.FromRepository2(repo, repo.Head, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			Assert.NotNull(tag);
 			tag!.Tag.Name.Should().Be("v1.0.0");
@@ -228,7 +228,7 @@ namespace UnitTests
 
 			var repo = new MockRepoInspector(gtor, master);
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
+			var (height, tag) = await HeightCalculator.FromRepository2(repo, repo.Head, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			Assert.NotNull(tag);
 			tag!.Tag.Name.Should().Be("v1.0.0");
@@ -245,7 +245,7 @@ namespace UnitTests
 				new("commit_c"),
 			});
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
+			var (height, tag) = await HeightCalculator.FromRepository2(repo, repo.Head, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			tag.Should().BeNull();
 			height.Should().Be(3);
@@ -261,7 +261,7 @@ namespace UnitTests
 				new("commit_c"),
 			});
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
+			var (height, tag) = await HeightCalculator.FromRepository2(repo, repo.Head, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			tag.Should().BeNull();
 			height.Should().Be(3);
@@ -278,7 +278,7 @@ namespace UnitTests
 				new("commit_c") { Tags = new[]{ "v" } },
 			});
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
+			var (height, tag) = await HeightCalculator.FromRepository2(repo, repo.Head, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			tag.Should().BeNull();
 			height.Should().Be(3);
@@ -294,7 +294,7 @@ namespace UnitTests
 				new("commit_c"),
 			});
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
+			var (height, tag) = await HeightCalculator.FromRepository2(repo, repo.Head, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			tag.Should().NotBeNull();
 			SDebug.Assert(tag is not null);
@@ -315,7 +315,7 @@ namespace UnitTests
 				new("commit_c"),
 			});
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, null);
+			var (height, tag) = await HeightCalculator.FromRepository2(repo, repo.Head, "v", queryRemoteTags: true, fetchTags: false, null, null);
 
 			tag.Should().NotBeNull();
 			SDebug.Assert(tag is not null);
@@ -360,7 +360,7 @@ namespace UnitTests
 				new("commit_d"),
 			});
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, prefix, queryRemoteTags: true, fetchTags: false, null, null);
+			var (height, tag) = await HeightCalculator.FromRepository2(repo, repo.Head, prefix, queryRemoteTags: true, fetchTags: false, null, null);
 
 			height.Should().Be(resultHeight);
 
@@ -395,7 +395,7 @@ namespace UnitTests
 			var filter = new MockTagFilter();
 			filter.BlockTags.Add("v1.0.0");
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, filter);
+			var (height, tag) = await HeightCalculator.FromRepository2(repo, repo.Head, "v", queryRemoteTags: true, fetchTags: false, null, filter);
 
 			tag.Should().NotBeNull();
 			SDebug.Assert(tag is not null);
@@ -418,7 +418,7 @@ namespace UnitTests
 			var filter = new MockTagFilter();
 			filter.BlockTags.Add("v1.0.0");
 
-			var (height, tag) = await HeightCalculator.FromRepository(repo, "v", queryRemoteTags: true, fetchTags: false, null, filter);
+			var (height, tag) = await HeightCalculator.FromRepository2(repo, repo.Head, "v", queryRemoteTags: true, fetchTags: false, null, filter);
 
 			tag.Should().NotBeNull();
 			SDebug.Assert(tag is not null);

--- a/tests/UnitTests/Mocks/MockRepoInspector.cs
+++ b/tests/UnitTests/Mocks/MockRepoInspector.cs
@@ -145,6 +145,16 @@ namespace UnitTests
 		{
 			return Head;
 		}
+		async Task<Commit?> IRepoInspector.ParseRevision(string revision)
+		{
+			if (revision == "HEAD")
+				return Head;
+
+			if (!Commits.TryGetValue(new Commit(revision), out var commit))
+				throw new RevParseException();
+
+			return new Commit(revision);
+		}
 
 		async Task<IReadOnlyList<Commit>> IRepoInspector.GetParents(Commit commit)
 		{

--- a/tests/UnitTests/VersionCalculationTests.cs
+++ b/tests/UnitTests/VersionCalculationTests.cs
@@ -108,7 +108,7 @@ namespace UnitTests
 		{
 			var repo = new MockRepoInspector(Array.Empty<MockRepoCommit>());
 
-			var (semver, lastTag, height) = await VersionCalculator.FromRepository2(repo, new() { QueryRemoteTags = true }, null, null);
+			var (semver, lastTag, height) = await VersionCalculator.FromRepository3(repo, repo.Head, new() { QueryRemoteTags = true }, null, null);
 
 			semver.Should().Be(new SemVer(0, 1, 0, "alpha.1"));
 			lastTag.Should().BeNull();
@@ -123,7 +123,7 @@ namespace UnitTests
 				new("commit_a"),
 			});
 
-			var (semver, lastTag, height) = await VersionCalculator.FromRepository2(repo, new() { QueryRemoteTags = true }, null, null);
+			var (semver, lastTag, height) = await VersionCalculator.FromRepository3(repo, repo.Head, new() { QueryRemoteTags = true }, null, null);
 
 			semver.Should().Be(new SemVer(0, 1, 0, "alpha.1"));
 			lastTag.Should().BeNull();
@@ -138,7 +138,7 @@ namespace UnitTests
 				new("commit_a") { Tags = new[] { "v5.4.3-rc.2.1" } },
 			});
 
-			var (semver, _, height) = await VersionCalculator.FromRepository2(repo, new() { QueryRemoteTags = true }, null, null);
+			var (semver, _, height) = await VersionCalculator.FromRepository3(repo, repo.Head, new() { QueryRemoteTags = true }, null, null);
 
 			semver.Should().Be(new SemVer(5, 4, 3, "rc.2.1"));
 			height.Should().Be(0);
@@ -153,7 +153,7 @@ namespace UnitTests
 				new("commit_a") { Tags = new[] { "v4.3.2-rc.1" } },
 			});
 
-			var (semver, _, height) = await VersionCalculator.FromRepository2(repo, new() { QueryRemoteTags = true }, null, null);
+			var (semver, _, height) = await VersionCalculator.FromRepository3(repo, repo.Head, new() { QueryRemoteTags = true }, null, null);
 
 			semver.Should().Be(new SemVer(4, 3, 2, "rc.1.1"));
 			height?.Should().Be(1);
@@ -168,7 +168,7 @@ namespace UnitTests
 				new("commit_a") { Tags = new[] { "v3.2.1" } },
 			});
 
-			var (semver, lastTag, height) = await VersionCalculator.FromRepository2(repo, new() { QueryRemoteTags = true }, null, null);
+			var (semver, lastTag, height) = await VersionCalculator.FromRepository3(repo, repo.Head, new() { QueryRemoteTags = true }, null, null);
 
 			semver.Should().Be(new SemVer(3, 2, 2, "alpha.1"));
 			lastTag?.Tag.Name.Should().Be("v3.2.1");
@@ -185,7 +185,7 @@ namespace UnitTests
 				new("commit_a") { Tags = new[] { "v3.2.0" } },
 			});
 
-			_ = await VersionCalculator.FromRepository2(repo, new() { QueryRemoteTags = true }, null, null);
+			_ = await VersionCalculator.FromRepository3(repo, repo.Head, new() { QueryRemoteTags = true }, null, null);
 
 			repo.LocalTags.Should().Contain(new Tag[] { new Tag("v3.2.1", new Commit("commit_b")) });
 		}
@@ -200,7 +200,7 @@ namespace UnitTests
 				new("commit_a") { Tags = new[] { "v3.2.0" } },
 			});
 
-			_ = await VersionCalculator.FromRepository2(repo, new() { QueryRemoteTags = false }, null, null);
+			_ = await VersionCalculator.FromRepository3(repo, repo.Head, new() { QueryRemoteTags = false }, null, null);
 
 			repo.LocalTags.Should().BeEmpty();
 		}
@@ -213,7 +213,7 @@ namespace UnitTests
 				new("commit_a") { Tags = new[] { "v1.2.3+4" } },
 			});
 
-			var (version, _, height) = await VersionCalculator.FromRepository2(repo, new()
+			var (version, _, height) = await VersionCalculator.FromRepository3(repo, repo.Head, new()
 			{
 				QueryRemoteTags = true,
 			}, null, null);
@@ -231,7 +231,7 @@ namespace UnitTests
 				new("commit_a") { Tags = new[] { "v1.2.3+4" } },
 			});
 
-			var (version, _, height) = await VersionCalculator.FromRepository2(repo, new()
+			var (version, _, height) = await VersionCalculator.FromRepository3(repo, repo.Head, new()
 			{
 				QueryRemoteTags = true,
 			}, null, null);
@@ -249,7 +249,7 @@ namespace UnitTests
 				new("commit_a") { Tags = new[] { "v1.2.3+4" } },
 			});
 
-			var (version, _, _) = await VersionCalculator.FromRepository2(repo, new()
+			var (version, _, _) = await VersionCalculator.FromRepository3(repo, repo.Head, new()
 			{
 				QueryRemoteTags = true,
 				BuildMetadata = "git.a1b2c3d",
@@ -266,7 +266,7 @@ namespace UnitTests
 				new("commit_a") { Tags = new[] { "v1.2.3" } },
 			});
 
-			var (version, _, _) = await VersionCalculator.FromRepository2(repo, new()
+			var (version, _, _) = await VersionCalculator.FromRepository3(repo, repo.Head, new()
 			{
 				QueryRemoteTags = true,
 				BuildMetadata = "git.a1b2c3d",
@@ -283,7 +283,7 @@ namespace UnitTests
 				new("commit_a") { Tags = new[] { "v1.2.3+4" } },
 			});
 
-			var (version, _, _) = await VersionCalculator.FromRepository2(repo, new()
+			var (version, _, _) = await VersionCalculator.FromRepository3(repo, repo.Head, new()
 			{
 				BuildMetadata = "git.a1b2c3d",
 				QueryRemoteTags = true,


### PR DESCRIPTION
- Add new methods for querying from a specified commit
- Added `IRepoInspector.ParseRevision()`
- GitRepoInspector: Catch Win32Exception (may be thrown if cat-file can't be terminated)
- Deprecate old versions of the functions

- [ ] Tests added
- [ ] Linked issue if exists
- [ ] Updated documentation
