### PR TITLE
Added shadow repo functionality for shallow clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ See [docs/VersionCalculation.md](docs/VersionCalculation.md) for further reading
 | A command to test whether a tag should be ignored via exit code.    | -f, --filter-tags, VerliteFilterTags                             |         |
 | The remote endpoint to use when fetching tags and commits.          | -r, --remote, VerliteRemote                                      | origin  |
 | Generate version strings and embed them via a source generator.     | VerliteEmbedVersion                                              | true    |
+| Use a shadow repo (partial, only commits) to read commit history.   | --enable-shadow-repo, EnableShadowRepo                           | false   |
 
 ## Comparison with GitVersion
 
@@ -261,6 +262,12 @@ public static class Version
 	public string Version => Verlite.Version.FullVersion;
 }
 ```
+
+<h3 id="shadow-repo">What is a shadow repo?</h3>
+
+Using a shadow repo is an experimental method of allowing shallow depth=1 clones without causing
+any issues with Verlite. A special repo within your repositories `.git` directory will be created
+and updated as needed, where only commits are fetched (via `--filter=tree:0`).
 
 [verlite-msbuild-badge]: https://img.shields.io/nuget/v/Verlite.MsBuild?label=Verlite.MsBuild
 [verlite-msbuild-link]: https://www.nuget.org/packages/Verlite.MsBuild

--- a/src/Verlite.CLI/Program.cs
+++ b/src/Verlite.CLI/Program.cs
@@ -89,6 +89,10 @@ namespace Verlite.CLI
 					aliases: new[] { "--enable-lightweight-tags" },
 					getDefaultValue: () => false,
 					description: "Create a lightweight tag instead of fetching the remote's."),
+				new Option<bool>(
+					aliases: new[] { "--enable-shadow-repo" },
+					getDefaultValue: () => false,
+					description: "Use a shadow repro for shallow clones using filter branches to fetch only commits."),
 				new Option<AutoIncrement>(
 					aliases: new[] { "--auto-increment", "-a" },
 					isDefault: true,
@@ -118,6 +122,7 @@ namespace Verlite.CLI
 			Show show,
 			bool autoFetch,
 			bool enableLightweightTags,
+			bool enableShadowRepo,
 			AutoIncrement autoIncrement,
 			string filterTags,
 			string remote,
@@ -155,6 +160,7 @@ namespace Verlite.CLI
 					using var repo = await GitRepoInspector.FromPath(sourceDirectory, opts.Remote, log, commandRunner);
 					repo.CanDeepen = autoFetch;
 					repo.EnableLightweightTags = enableLightweightTags;
+					repo.EnableShadowRepo = enableShadowRepo;
 
 					ITagFilter? tagFilter = null;
 					if (!string.IsNullOrWhiteSpace(filterTags))

--- a/src/Verlite.Core/Command.cs
+++ b/src/Verlite.Core/Command.cs
@@ -101,8 +101,14 @@ namespace Verlite
 			proc.Start();
 			proc.StandardInput.Close();
 
-			string stdout = await proc.StandardOutput.ReadToEndAsync();
-			string stderr = await proc.StandardError.ReadToEndAsync();
+			Task<string> stdoutTask = proc.StandardOutput.ReadToEndAsync();
+			Task<string> stderrTask = proc.StandardError.ReadToEndAsync();
+
+			await Task.WhenAll(stdoutTask, stderrTask, exitPromise.Task);
+
+			string stdout = await stdoutTask;
+			string stderr = await stderrTask;
+			int exitCode = await exitPromise.Task;
 
 			if (await exitPromise.Task != 0)
 				throw new CommandException(proc.ExitCode, stdout, stderr);

--- a/src/Verlite.Core/GitCatFileProcess.cs
+++ b/src/Verlite.Core/GitCatFileProcess.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Verlite
+{
+	internal sealed class GitCatFileProcess : IDisposable
+	{
+		internal Process? CatFileProcess { get; set; }
+		internal Process? ShadowCatFileProcess { get; set; }
+		private UTF8Encoding Encoding { get; } = new(
+			encoderShouldEmitUTF8Identifier: false,
+			throwOnInvalidBytes: false);
+
+		private char[] WhitespaceChars { get; } = new[]
+		{
+			'\t',
+			'\v',
+			'\f',
+			'\r',
+			'\n',
+			' ',
+			'\u0085', // NEXT LINE
+			'\u00A0', // NBSP
+			'\u1680', // OGHAM SPACE MARK
+			'\u2000', // EN QUAD
+			'\u2001', // EM QUAD
+			'\u2002', // EN SPACE
+			'\u2003', // EM SPACE
+			'\u2004', // THREE-PER-EM SPACE
+			'\u2005', // FOUR-PER-EM SPACE
+			'\u2006', // SIX-PER-EM SPACE
+			'\u2007', // FIGURE SPACE
+			'\u2008', // PUNCTUATION SPACE
+			'\u2009', // THIN SPACE
+			'\u200A', // HAIR SPACE
+			'\u2028', // LINE SEPARATOR
+			'\u2029', // PARAGRAPH SEPARATOR
+			'\u202F', // NARROW NBSP
+			'\u205F', // MEDIUM MATHEMATICAL SPACE
+			'\u3000', // IDEOGRAPHIC SPACE
+			'\u180E', // MONGOLIAN VOWEL SEPARATOR
+			'\u200B', // ZERO WIDTH SPACE
+			'\u200C', // ZERO WIDTH NON-JOINER
+			'\u200D', // ZERO WIDTH JOINER
+			'\u2060', // WORD JOINER
+			'\uFEFF', // ZERO WIDTH NON-BREAKING SPACE
+		};
+
+		private ILogger? Log { get; }
+		private string Root { get; }
+		private string Name { get; }
+		public GitCatFileProcess(ILogger? log, string root, string name)
+		{
+			Root = root;
+			Name = name;
+		}
+
+		private readonly SemaphoreSlim catFileSemaphore = new(initialCount: 1, maxCount: 1);
+		public async Task<string?> ReadObject(string type, string id)
+		{
+			await catFileSemaphore.WaitAsync();
+			try
+			{
+
+				bool isFirst = false;
+				if (CatFileProcess is null)
+				{
+					isFirst = true;
+
+					Log?.Verbatim($"{Root} $ git cat-file --batch");
+					ProcessStartInfo info = new()
+					{
+						FileName = "git",
+						Arguments = "cat-file --batch",
+						WorkingDirectory = Root,
+						RedirectStandardError = false,
+						RedirectStandardOutput = true,
+						StandardOutputEncoding = Encoding,
+						RedirectStandardInput = true,
+						UseShellExecute = false,
+					};
+					CatFileProcess = Process.Start(info);
+				}
+
+				var (cin, cout) = (CatFileProcess.StandardInput, CatFileProcess.StandardOutput.BaseStream);
+
+				// if this git call is forwarded onto another shell script,
+				// then it's possible to query git before it's ready, but once
+				// it does respond, it's ready to be used.
+				if (isFirst)
+				{
+					Log?.Verbatim($"First run: awaiting cat-file startup ({Name})");
+					await cin.WriteLineAsync(" ");
+
+					using var cts = new CancellationTokenSource();
+
+					var timeout = Task.Delay(5000, cts.Token);
+					var gotBack = ReadLineAsync(cout);
+
+					var completedTask = await Task.WhenAny(timeout, gotBack);
+
+					if (completedTask != timeout)
+						cts.Cancel();
+					else
+						throw new UnknownGitException($"The git cat-file process timed out ({Name})");
+
+					var result = await gotBack;
+					if (result.Trim(WhitespaceChars) != "missing")
+						throw new UnknownGitException($"The git cat-file process returned unexpected output: {result} ({Name})");
+				}
+
+				using var cts2 = new CancellationTokenSource();
+				var timeout2 = Task.Delay(30_000, cts2.Token);
+
+				Log?.Verbatim($"git cat-file < {id} ({Name})");
+				if (await Task.WhenAny(cin.WriteLineAsync(id), timeout2) == timeout2)
+					throw new UnknownGitException($"The git cat-file process write timed out ({Name})");
+
+				var readLineTask = ReadLineAsync(cout);
+				if (await Task.WhenAny(readLineTask, timeout2) == timeout2)
+					throw new UnknownGitException($"The git cat-file process read timed out ({Name})");
+
+				string line = await readLineTask;
+				Log?.Verbatim($"git cat-file > {line} ({Name})");
+				string[] response = line.Trim(WhitespaceChars).Split(' ');
+
+
+				if (response[0] != id)
+					throw new UnknownGitException($"The returned blob hash did not match ({Name})");
+				else if (response[1] == "missing")
+					return null;
+				else if (response[1] != type)
+					throw new UnknownGitException($"Blob for {id} expected {type} but was {response[1]} ({Name})");
+
+				var length = int.Parse(response[2], CultureInfo.InvariantCulture);
+				var buffer = new byte[length];
+
+				if (await Task.WhenAny(cout.ReadAsync(buffer, 0, length), timeout2) == timeout2)
+					throw new UnknownGitException($"The git cat-file process read block timed out ({Name})");
+				if (await Task.WhenAny(ReadLineAsync(cout), timeout2) == timeout2)
+					throw new UnknownGitException($"The git cat-file process read block line timed out ({Name})");
+
+				cts2.Cancel();
+				return Encoding.GetString(buffer);
+			}
+			catch (Exception ex)
+			{
+				throw new UnknownGitException($"Failed to communicate with the git cat-file process: {ex.Message} ({Name})");
+			}
+			finally
+			{
+				catFileSemaphore.Release();
+			}
+		}
+
+		private async Task<string> ReadLineAsync(Stream stream, int maxLength = 128)
+		{
+			var buffer = new byte[maxLength];
+
+			int length = 0;
+			for (; length < maxLength; length++)
+			{
+				if (await stream.ReadAsync(buffer, length, 1) == -1)
+					break;
+				else if (buffer[length] == '\n')
+					break;
+			}
+
+			return Encoding.GetString(buffer, 0, length);
+		}
+
+		public void Dispose()
+		{
+			try
+			{
+				CatFileProcess?.StandardInput.Close();
+				CatFileProcess?.Kill();
+				CatFileProcess?.Close();
+				catFileSemaphore.Dispose();
+			}
+			catch (IOException) { } // process may already be terminated
+			catch (System.ComponentModel.Win32Exception) { }
+			finally { }
+		}
+
+		internal Process? GetProcess()
+		{
+			return CatFileProcess;
+		}
+	}
+}

--- a/src/Verlite.Core/GitShadowRepo.cs
+++ b/src/Verlite.Core/GitShadowRepo.cs
@@ -1,0 +1,73 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+
+namespace Verlite
+{
+	internal class GitShadowRepo : IDisposable
+	{
+		public static async Task<GitShadowRepo> FromPath(
+			ILogger? log,
+			ICommandRunner runner,
+			string gitRoot,
+			string remoteName)
+		{
+			var (remoteUrl, _) = await runner.Run(gitRoot, "git", new[] { "remote", "get-url", remoteName });
+			var (gitDir, _) = await runner.Run(gitRoot, "git", new[] { "rev-parse", "--git-dir" });
+			string root = Path.Combine(gitRoot, gitDir, "verlite-shadow");
+
+			if (!Directory.Exists(root))
+			{
+				log?.Verbose($"Shadow clone does not exist, creating at {root}");
+				Directory.CreateDirectory(root);
+				await runner.Run(root, "git", new[] { "init", "--bare" });
+				await runner.Run(root, "git", new[] { "config", "fetch.recurseSubmodules", "false" });
+				await runner.Run(root, "git", new[] { "fetch", remoteUrl, "--filter=tree:0", "--no-tags" });
+			}
+
+			return new GitShadowRepo(
+				log,
+				runner,
+				root,
+				remoteUrl);
+		}
+
+		public ILogger? Log { get; }
+		public ICommandRunner CmdRunner { get; }
+		public string Root { get; }
+		public string RemoteUrl { get; }
+		private GitShadowRepo(ILogger? log, ICommandRunner runner, string root, string remoteUrl)
+		{
+			Log = log;
+			CmdRunner = runner;
+			Root = root;
+			RemoteUrl = remoteUrl;
+		}
+
+		private GitCatFileProcess? CatFileProcess { get; set; }
+		public async Task<string?> ReadObject(string type, string id, bool canFetch)
+		{
+			CatFileProcess ??= new GitCatFileProcess(Log, Root, "shadow");
+
+			string? contents = await CatFileProcess.ReadObject(type, id);
+			if (contents is not null || !canFetch)
+				return contents;
+
+			try
+			{
+				await CmdRunner.Run(Root, "git", new[] { "fetch", RemoteUrl, "--filter=tree:0", "--prune", "--force" });
+			}
+			catch (CommandException)
+			{
+				await CmdRunner.Run(Root, "git", new[] { "fetch", RemoteUrl, "--filter=tree:0", "--prune", "--force", "--refetch" });
+			}
+
+			return await CatFileProcess.ReadObject(type, id);
+		}
+
+		public void Dispose()
+		{
+			CatFileProcess?.Dispose();
+		}
+	}
+}

--- a/src/Verlite.Core/PublicAPI.Unshipped.txt
+++ b/src/Verlite.Core/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
 #nullable enable
-Verlite.GitRepoInspector.EnableShadow.get -> bool
-Verlite.GitRepoInspector.EnableShadow.set -> void
+Verlite.GitRepoInspector.EnableShadowRepo.get -> bool
+Verlite.GitRepoInspector.EnableShadowRepo.set -> void

--- a/src/Verlite.Core/PublicAPI.Unshipped.txt
+++ b/src/Verlite.Core/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Verlite.GitRepoInspector.EnableShadow.get -> bool
+Verlite.GitRepoInspector.EnableShadow.set -> void

--- a/src/Verlite.MsBuild/GetVersionTask.cs
+++ b/src/Verlite.MsBuild/GetVersionTask.cs
@@ -21,6 +21,7 @@ namespace Verlite.MsBuild
 		public string AutoIncrement { get; set; } = "";
 		public string FilterTags { get; set; } = "";
 		public string Remote { get; set; } = "";
+		public bool EnableShadowRepo { get; set; } = false;
 
 		public override bool Execute()
 		{
@@ -113,6 +114,7 @@ namespace Verlite.MsBuild
 			if (opts.VersionOverride is null)
 			{
 				using var repo = await GitRepoInspector.FromPath(ProjectDirectory, opts.Remote, log, commandRunner);
+				repo.EnableShadowRepo = EnableShadowRepo;
 
 				ITagFilter? tagFilter = null;
 				if (!string.IsNullOrWhiteSpace(FilterTags))

--- a/src/Verlite.MsBuild/GetVersionTask.cs
+++ b/src/Verlite.MsBuild/GetVersionTask.cs
@@ -21,7 +21,7 @@ namespace Verlite.MsBuild
 		public string AutoIncrement { get; set; } = "";
 		public string FilterTags { get; set; } = "";
 		public string Remote { get; set; } = "";
-		public bool EnableShadowRepo { get; set; } = false;
+		public bool EnableShadowRepo { get; set; }
 
 		public override bool Execute()
 		{

--- a/src/Verlite.MsBuild/build/Verlite.MsBuild.targets
+++ b/src/Verlite.MsBuild/build/Verlite.MsBuild.targets
@@ -58,6 +58,7 @@ This file has been modified by Ashleigh Adams and adapted for Verlite -->
     <Message Importance="$(VerliteDetailed)" Text="Verlite: [input] VerliteAutoIncrement=$(VerliteAutoIncrement)" />
     <Message Importance="$(VerliteDetailed)" Text="Verlite: [input] VerliteFilterTags=$(VerliteFilterTags)" />
     <Message Importance="$(VerliteDetailed)" Text="Verlite: [input] VerliteRemote=$(VerliteRemote)" />
+    <Message Importance="$(VerliteDetailed)" Text="Verlite: [input] VerliteEnableShadowRepo=$(VerliteEnableShadowRepo)" />
 
     <Verlite.MsBuild.GetVersionTask ProjectDirectory="$(MSBuildProjectDirectory)"
                                     BuildMetadata="$(VerliteBuildMetadata)"
@@ -70,7 +71,8 @@ This file has been modified by Ashleigh Adams and adapted for Verlite -->
                                     PrereleaseBaseHeight="$(VerlitePrereleaseBaseHeight)"
                                     AutoIncrement="$(VerliteAutoIncrement)"
                                     FilterTags="$(VerliteFilterTags)"
-                                    Remote="$(VerliteRemote)" >
+                                    Remote="$(VerliteRemote)"
+                                    EnableShadowRepo="$(VerliteEnableShadowRepo)">
       <Output TaskParameter="Version" PropertyName="VerliteVersion" />
       <Output TaskParameter="VersionMajor" PropertyName="VerliteMajor" />
       <Output TaskParameter="VersionMinor" PropertyName="VerliteMinor" />


### PR DESCRIPTION
Bitbucket would not play nice with particularly deep, long lived, branches.

A possible path to the root commit can be found under certain workloads, which resulted in fetching the entire history.