### PR TITLE
Harded shadow repo against filterspec woes

### DIFF
--- a/src/Verlite.Core/GitShadowRepo.cs
+++ b/src/Verlite.Core/GitShadowRepo.cs
@@ -59,6 +59,7 @@ namespace Verlite
 			}
 			catch (CommandException)
 			{
+				Log?.Verbose($"Shadow repo fetch failed during ReadObject(), trying with --refetch");
 				await CmdRunner.Run(Root, "git", new[] { "fetch", RemoteUrl, "--filter=tree:0", "--prune", "--force", "--refetch" });
 			}
 
@@ -69,8 +70,26 @@ namespace Verlite
 		{
 			var (remoteUrl, _) = await CmdRunner.Run(gitRoot, "git", new[] { "remote", "get-url", remoteName });
 
-			await CmdRunner.Run(Root,
-				"git", new[] { "fetch", remoteUrl, $"+refs/tags/{tag.Name}:refs/tags/{tag.Name}", "--filter=tree:0" });
+			try
+			{
+				await CmdRunner.Run(Root,
+					"git", new[] {
+						"fetch", remoteUrl,
+						$"+refs/tags/{tag.Name}:refs/tags/{tag.Name}",
+						"--filter=tree:0",
+					});
+			}
+			catch (CommandException)
+			{
+				Log?.Verbose($"Shadow repo fetch failed during FetchTag(), trying with --refetch");
+				await CmdRunner.Run(Root,
+					"git", new[] {
+						"fetch", remoteUrl,
+						$"+refs/tags/{tag.Name}:refs/tags/{tag.Name}",
+						"--filter=tree:0",
+						"--refetch",
+					});
+			}
 		}
 
 		public void Dispose()


### PR DESCRIPTION
Sometimes the client/host fails to reconcile the differences with filterspecs, particularly with Bitbucket returning the following error after some upstream refs have changed:

fatal: multiple filter-specs cannot be combined

By trying again with --refetch, we "forget" all of the old repo information, instead of trying to work out a delta, which is a more stable path on Bitbucket.