### PR TITLE
Support AutoIncrement.None 

### DIFF
--- a/src/Verlite.CLI/AutoIncrement.cs
+++ b/src/Verlite.CLI/AutoIncrement.cs
@@ -5,10 +5,10 @@ namespace Verlite.CLI
 {
 	internal enum AutoIncrement
 	{
-		none = -1,
 		patch = default,
 		minor = 1,
 		major = 2,
+		none = 3,
 	}
 
 	internal static partial class Parsers

--- a/src/Verlite.CLI/AutoIncrement.cs
+++ b/src/Verlite.CLI/AutoIncrement.cs
@@ -5,6 +5,7 @@ namespace Verlite.CLI
 {
 	internal enum AutoIncrement
 	{
+		none = -1,
 		patch = default,
 		minor = 1,
 		major = 2,
@@ -19,6 +20,7 @@ namespace Verlite.CLI
 				AutoIncrement.patch => VersionPart.Patch,
 				AutoIncrement.minor => VersionPart.Minor,
 				AutoIncrement.major => VersionPart.Major,
+				AutoIncrement.none  => VersionPart.None,
 				_ => throw new ArgumentException("Unknown or invalid auto increment.", nameof(self)),
 			};
 		}
@@ -40,6 +42,7 @@ namespace Verlite.CLI
 				"MAJOR" => AutoIncrement.major,
 				"MINOR" => AutoIncrement.minor,
 				"PATCH" => AutoIncrement.patch,
+				"NONE" => AutoIncrement.none,
 				_ => invalid(),
 			};
 		}

--- a/src/Verlite.CLI/Program.cs
+++ b/src/Verlite.CLI/Program.cs
@@ -111,7 +111,7 @@ namespace Verlite.CLI
 			return await rootCommand.InvokeAsync(args);
 		}
 
-		private async static Task RootCommandAsync(
+		private static async Task RootCommandAsync(
 			string tagPrefix,
 			string defaultPrereleasePhase,
 			SemVer minVersion,

--- a/src/Verlite.Core/Command.cs
+++ b/src/Verlite.Core/Command.cs
@@ -110,7 +110,7 @@ namespace Verlite
 			string stderr = await stderrTask;
 			int exitCode = await exitPromise.Task;
 
-			if (await exitPromise.Task != 0)
+			if (exitCode != 0)
 				throw new CommandException(proc.ExitCode, stdout, stderr);
 
 			return (stdout.Trim(), stderr.Trim());

--- a/src/Verlite.Core/VersionCalculator.cs
+++ b/src/Verlite.Core/VersionCalculator.cs
@@ -23,11 +23,8 @@ namespace Verlite
 		{
 			if (height < 1)
 				throw new ArgumentOutOfRangeException(nameof(height), height, "Must be greater than zero.");
-
 			if (options.AutoIncrement == VersionPart.None)
-			{
 				return version;
-			}
 
 			SemVer ret = version;
 			ret.Prerelease ??= options.DefaultPrereleasePhase;
@@ -49,21 +46,19 @@ namespace Verlite
 				return options.MinimumVersion;
 			if (options.AutoIncrement == VersionPart.None)
 				return lastTag;
-
-			if (lastTag.Prerelease is null)
+			if (lastTag.Prerelease is not null)
 			{
-				return options.AutoIncrement switch
-				{
-					VersionPart.Patch => new SemVer(lastTag.Major, lastTag.Minor, lastTag.Patch + 1),
-					VersionPart.Minor => new SemVer(lastTag.Major, lastTag.Minor + 1, 0),
-					VersionPart.Major => new SemVer(lastTag.Major + 1, 0, 0),
-					_ => throw new InvalidOperationException("NextVersion(): Can only bump by major, minor, or patch (default)."),
-				};
+				var ret = lastTag;
+				ret.BuildMetadata = null;
+				return ret;
 			}
-
-			var ret = lastTag;
-			ret.BuildMetadata = null;
-			return ret;
+			return options.AutoIncrement switch
+			{
+				VersionPart.Patch => new SemVer(lastTag.Major, lastTag.Minor, lastTag.Patch + 1),
+				VersionPart.Minor => new SemVer(lastTag.Major, lastTag.Minor + 1, 0),
+				VersionPart.Major => new SemVer(lastTag.Major + 1, 0, 0),
+				_ => throw new InvalidOperationException("NextVersion(): Can only bump by major, minor, or patch (default)."),
+			};
 		}
 
 		/// <summary>

--- a/src/Verlite.Core/VersionCalculator.cs
+++ b/src/Verlite.Core/VersionCalculator.cs
@@ -24,13 +24,15 @@ namespace Verlite
 			if (height < 1)
 				throw new ArgumentOutOfRangeException(nameof(height), height, "Must be greater than zero.");
 
-			SemVer ret = version;
-			if (options.AutoIncrement != VersionPart.None)
+			if (options.AutoIncrement == VersionPart.None)
 			{
-				ret.Prerelease ??= options.DefaultPrereleasePhase;
-				ret.BuildMetadata = options.BuildMetadata;
-				ret.Prerelease += $".{options.PrereleaseBaseHeight + (height - 1)}";
+				return version;
 			}
+
+			SemVer ret = version;
+			ret.Prerelease ??= options.DefaultPrereleasePhase;
+			ret.BuildMetadata = options.BuildMetadata;
+			ret.Prerelease += $".{options.PrereleaseBaseHeight + (height - 1)}";
 
 			return ret;
 		}
@@ -45,12 +47,13 @@ namespace Verlite
 		{
 			if (options.MinimumVersion > lastTag.CoreVersion)
 				return options.MinimumVersion;
+			if (options.AutoIncrement == VersionPart.None)
+				return lastTag;
 
 			if (lastTag.Prerelease is null)
 			{
 				return options.AutoIncrement switch
 				{
-					VersionPart.None => lastTag,
 					VersionPart.Patch => new SemVer(lastTag.Major, lastTag.Minor, lastTag.Patch + 1),
 					VersionPart.Minor => new SemVer(lastTag.Major, lastTag.Minor + 1, 0),
 					VersionPart.Major => new SemVer(lastTag.Major + 1, 0, 0),

--- a/src/Verlite.Core/VersionCalculator.cs
+++ b/src/Verlite.Core/VersionCalculator.cs
@@ -45,13 +45,9 @@ namespace Verlite
 		{
 			if (options.MinimumVersion > lastTag.CoreVersion)
 				return options.MinimumVersion;
-			else if (lastTag.Prerelease is not null)
+
+			if (lastTag.Prerelease is null)
 			{
-				var ret = lastTag;
-				ret.BuildMetadata = null;
-				return ret;
-			}
-			else
 				return options.AutoIncrement switch
 				{
 					VersionPart.None => lastTag,
@@ -60,6 +56,11 @@ namespace Verlite
 					VersionPart.Major => new SemVer(lastTag.Major + 1, 0, 0),
 					_ => throw new InvalidOperationException("NextVersion(): Can only bump by major, minor, or patch (default)."),
 				};
+			}
+
+			var ret = lastTag;
+			ret.BuildMetadata = null;
+			return ret;
 		}
 
 		/// <summary>

--- a/src/Verlite.Core/VersionCalculator.cs
+++ b/src/Verlite.Core/VersionCalculator.cs
@@ -25,9 +25,12 @@ namespace Verlite
 				throw new ArgumentOutOfRangeException(nameof(height), height, "Must be greater than zero.");
 
 			SemVer ret = version;
-			ret.Prerelease ??= options.DefaultPrereleasePhase;
-			ret.Prerelease += $".{options.PrereleaseBaseHeight + (height - 1)}";
-			ret.BuildMetadata = options.BuildMetadata;
+			if (options.AutoIncrement != VersionPart.None)
+			{
+				ret.Prerelease ??= options.DefaultPrereleasePhase;
+				ret.BuildMetadata = options.BuildMetadata;
+				ret.Prerelease += $".{options.PrereleaseBaseHeight + (height - 1)}";
+			}
 
 			return ret;
 		}
@@ -51,6 +54,7 @@ namespace Verlite
 			else
 				return options.AutoIncrement switch
 				{
+					VersionPart.None => lastTag,
 					VersionPart.Patch => new SemVer(lastTag.Major, lastTag.Minor, lastTag.Patch + 1),
 					VersionPart.Minor => new SemVer(lastTag.Major, lastTag.Minor + 1, 0),
 					VersionPart.Major => new SemVer(lastTag.Major + 1, 0, 0),

--- a/tests/UnitTests/VersionCalculationTests.cs
+++ b/tests/UnitTests/VersionCalculationTests.cs
@@ -49,23 +49,25 @@ namespace UnitTests
 
 
 		[Theory]
-		//               lastTag   minVersion, height,          result
-		[InlineData(null, null, 1, "0.1.0")]
-		[InlineData(null, null, 10, "0.1.0")]
-		[InlineData("0.1.0-rc.1", null, 0, "0.1.0-rc.1")]
-		[InlineData("0.1.0-rc.1", null, 1, "0.1.0-rc.1")]
-		[InlineData("0.1.0-rc.1", null, 2, "0.1.0-rc.1")]
-		[InlineData("1.0.0-rc.2", "1.0.0", 0, "1.0.0-rc.2")]
-		[InlineData("1.0.0-rc.2", "1.0.0", 1, "1.0.0-rc.2")]
-		[InlineData("1.0.0-rc.2", "1.0.0", 2, "1.0.0-rc.2")]
-		[InlineData("0.1.0-rc.1", "1.0.0", 1, "1.0.0")]
-		[InlineData("0.1.0-rc.1", "1.0.0", 3, "1.0.0")]
-		[InlineData("1.0.0", null, 0, "1.0.0")]
-		[InlineData("1.0.0", "1.0.0", 0, "1.0.0")]
-		[InlineData("1.0.0", "1.0.0", 1, "1.0.0")]
-		[InlineData("1.0.0", "2.0.0", 1, "2.0.0")]
-		[InlineData("1.0.0-pre+meta", null, 0, "1.0.0-pre+meta")]
-		[InlineData("1.0.0+meta", null, 0, "1.0.0+meta")]
+		//               lastTag,     minVersion, height,      result
+		[InlineData(            null,     null,      1,           "0.1.0")]
+		[InlineData(            null,     null,     10,           "0.1.0")]
+		[InlineData(    "0.1.0-rc.1",     null,      0,      "0.1.0-rc.1")]
+		[InlineData(    "0.1.0-rc.1",     null,      1,      "0.1.0-rc.1")]
+		[InlineData(    "0.1.0-rc.1",     null,      2,      "0.1.0-rc.1")]
+		[InlineData(    "1.0.0-rc.2",  "1.0.0",      0,      "1.0.0-rc.2")]
+		[InlineData(    "1.0.0-rc.2",  "1.0.0",      1,      "1.0.0-rc.2")]
+		[InlineData(    "1.0.0-rc.2",  "1.0.0",      2,      "1.0.0-rc.2")]
+		[InlineData(    "0.1.0-rc.1",  "1.0.0",      1,           "1.0.0")]
+		[InlineData(    "0.1.0-rc.1",  "1.0.0",      3,           "1.0.0")]
+		[InlineData(         "1.0.0",     null,      0,           "1.0.0")]
+		[InlineData(         "1.0.0",  "1.0.0",      0,           "1.0.0")]
+		[InlineData(         "1.0.0",  "1.0.0",      1,           "1.0.0")]
+		[InlineData(         "1.0.0",  "2.0.0",      1,           "2.0.0")]
+		[InlineData("1.0.0-pre+meta",     null,      0,  "1.0.0-pre+meta")]
+		[InlineData(    "1.0.0+meta",     null,      0,      "1.0.0+meta")]
+		[InlineData(    "1.0.0+meta",  "2.0.0",      1,           "2.0.0")]
+		[InlineData(    "1.0.0+meta", "2.0.0+x",      1,        "2.0.0+x")]
 		public void CheckVersionDoesNotBump(string? versionStr, string? minVer, int height, string resultStr)
 		{
 			var options = new VersionCalculationOptions()

--- a/tests/UnitTests/VersionCalculationTests.cs
+++ b/tests/UnitTests/VersionCalculationTests.cs
@@ -47,6 +47,42 @@ namespace UnitTests
 			gotVersion.ToString().Should().Be(resultStr);
 		}
 
+
+		[Theory]
+		//               lastTag   minVersion, height,          result
+		[InlineData(null, null, 1, "0.1.0")]
+		[InlineData(null, null, 10, "0.1.0")]
+		[InlineData("0.1.0-rc.1", null, 0, "0.1.0-rc.1")]
+		[InlineData("0.1.0-rc.1", null, 1, "0.1.0-rc.1")]
+		[InlineData("0.1.0-rc.1", null, 2, "0.1.0-rc.1")]
+		[InlineData("1.0.0-rc.2", "1.0.0", 0, "1.0.0-rc.2")]
+		[InlineData("1.0.0-rc.2", "1.0.0", 1, "1.0.0-rc.2")]
+		[InlineData("1.0.0-rc.2", "1.0.0", 2, "1.0.0-rc.2")]
+		[InlineData("0.1.0-rc.1", "1.0.0", 1, "1.0.0")]
+		[InlineData("0.1.0-rc.1", "1.0.0", 3, "1.0.0")]
+		[InlineData("1.0.0", null, 0, "1.0.0")]
+		[InlineData("1.0.0", "1.0.0", 0, "1.0.0")]
+		[InlineData("1.0.0", "1.0.0", 1, "1.0.0")]
+		[InlineData("1.0.0", "2.0.0", 1, "2.0.0")]
+		[InlineData("1.0.0-pre+meta", null, 0, "1.0.0-pre+meta")]
+		[InlineData("1.0.0+meta", null, 0, "1.0.0+meta")]
+		public void CheckVersionDoesNotBump(string? versionStr, string? minVer, int height, string resultStr)
+		{
+			var options = new VersionCalculationOptions()
+			{
+				MinimumVersion = SemVer.Parse(minVer ?? "0.1.0"),
+				AutoIncrement = VersionPart.None
+			};
+
+			var version = versionStr is null ? (SemVer?)null : SemVer.Parse(versionStr);
+			var result = SemVer.Parse(resultStr);
+
+			var gotVersion = VersionCalculator.FromTagInfomation(version, options, height);
+
+			gotVersion.Should().Be(result);
+			gotVersion.ToString().Should().Be(resultStr);
+		}
+
 		[Fact]
 		public void BumpWithInvalidHeightThrows()
 		{
@@ -58,14 +94,18 @@ namespace UnitTests
 		}
 
 		[Theory]
+		[InlineData("1.0.0", VersionPart.None, "1.0.0")]
 		[InlineData("1.0.0", VersionPart.Patch, "1.0.1")]
 		[InlineData("1.0.0", VersionPart.Minor, "1.1.0")]
 		[InlineData("1.0.0", VersionPart.Major, "2.0.0")]
+		[InlineData("1.1.2", VersionPart.None, "1.1.2")]
 		[InlineData("1.1.2", VersionPart.Patch, "1.1.3")]
 		[InlineData("1.1.2", VersionPart.Minor, "1.2.0")]
 		[InlineData("1.1.2", VersionPart.Major, "2.0.0")]
 		[InlineData("1.1.2+abc", VersionPart.Major, "2.0.0")]
+		[InlineData("1.1.2+abc", VersionPart.None, "1.1.2+abc")]
 		[InlineData("1.0.0-alpha.1", VersionPart.Patch, "1.0.0-alpha.1")]
+		[InlineData("1.0.0-alpha.1+data.2", VersionPart.None, "1.0.0-alpha.1+data.2")]
 		[InlineData("1.0.0-alpha.1+data.2", VersionPart.Patch, "1.0.0-alpha.1")]
 		[InlineData("1.0.0-alpha.1+data.2", VersionPart.Minor, "1.0.0-alpha.1")]
 		[InlineData("1.0.0-alpha.1+data.2", VersionPart.Major, "1.0.0-alpha.1")]
@@ -81,16 +121,6 @@ namespace UnitTests
 			var actualNext = VersionCalculator.NextVersion(version, opts);
 
 			actualNext.Should().Be(expectedNext);
-		}
-
-		[Fact]
-		public void NextVersionWithInvalidAutoIncrementThrows()
-		{
-			var opts = new VersionCalculationOptions()
-			{
-				AutoIncrement = VersionPart.None,
-			};
-			Assert.Throws<InvalidOperationException>(() => VersionCalculator.NextVersion(new SemVer(1, 0, 0), opts));
 		}
 
 		[Fact]


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md -->


## Summary
In order to help support returning the last tag recorded without bumping any components, changes to the AutoIncrement enum support were required.

Are there any concerns or areas to be aware of regarding the approach taken or areas changed?

## Tests
- Added unit test to verify the last recorded tag or min version specified are returned as-is
- Tested `-a none` argument being used thru Visual Studio debugger

- [x] Tests added
- [x] Linked issue if exists
- [ ] Updated Documentation