### PR TITLE
Update precedence rules such that "post release" versioning is possible for metadata

### DIFF
--- a/.github/shared.yml
+++ b/.github/shared.yml
@@ -17,9 +17,7 @@ definitions:
       dotnet-version: |
         3.1.x
         5.0.x
-        6.x
-        7.x
-        8.x
+        9.x
 
   setup-nuget: &setup-nuget
     name: Setup NuGet

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -36,9 +36,7 @@ jobs:
         dotnet-version: |
           3.1.x
           5.0.x
-          6.x
-          7.x
-          8.x
+          9.x
 
     - name: Restore
       run: dotnet restore
@@ -97,9 +95,7 @@ jobs:
         dotnet-version: |
           3.1.x
           5.0.x
-          6.x
-          7.x
-          8.x
+          9.x
 
     - name: Publish
       run: |
@@ -137,9 +133,7 @@ jobs:
         dotnet-version: |
           3.1.x
           5.0.x
-          6.x
-          7.x
-          8.x
+          9.x
 
     - name: Mutation Test
       run: |
@@ -191,9 +185,7 @@ jobs:
         dotnet-version: |
           3.1.x
           5.0.x
-          6.x
-          7.x
-          8.x
+          9.x
 
     - name: Run Integration Tests
       run: |
@@ -218,9 +210,7 @@ jobs:
         dotnet-version: |
           3.1.x
           5.0.x
-          6.x
-          7.x
-          8.x
+          9.x
 
     - name: Setup NuGet
       run: |

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -36,9 +36,7 @@ jobs:
         dotnet-version: |
           3.1.x
           5.0.x
-          6.x
-          7.x
-          8.x
+          9.x
 
     - name: Restore
       run: dotnet restore
@@ -97,9 +95,7 @@ jobs:
         dotnet-version: |
           3.1.x
           5.0.x
-          6.x
-          7.x
-          8.x
+          9.x
 
     - name: Publish
       run: |
@@ -137,9 +133,7 @@ jobs:
         dotnet-version: |
           3.1.x
           5.0.x
-          6.x
-          7.x
-          8.x
+          9.x
 
     - name: Mutation Test
       run: |
@@ -191,9 +185,7 @@ jobs:
         dotnet-version: |
           3.1.x
           5.0.x
-          6.x
-          7.x
-          8.x
+          9.x
 
     - name: Run Integration Tests
       run: |

--- a/.github/workflows/deploy-release.yml
+++ b/.github/workflows/deploy-release.yml
@@ -27,9 +27,7 @@ jobs:
         dotnet-version: |
           3.1.x
           5.0.x
-          6.x
-          7.x
-          8.x
+          9.x
 
     - name: Setup NuGet
       run: |
@@ -98,9 +96,7 @@ jobs:
         dotnet-version: |
           3.1.x
           5.0.x
-          6.x
-          7.x
-          8.x
+          9.x
 
     - name: Publish
       run: |
@@ -140,9 +136,7 @@ jobs:
         dotnet-version: |
           3.1.x
           5.0.x
-          6.x
-          7.x
-          8.x
+          9.x
 
     - name: Setup NuGet
       run: |

--- a/Verlite.sln
+++ b/Verlite.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29509.3
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35514.174 d17.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D0F10406-C62D-49CE-A369-4CEDB84DC800}"
 	ProjectSection(SolutionItems) = preProject
@@ -9,6 +9,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
 		Directory.Build.props = Directory.Build.props
+		global.json = global.json
 		NuGet.config = NuGet.config
 		README.md = README.md
 	EndProjectSection

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+	"sdk": {
+		"version": "9.0.0",
+		"rollForward": "latestFeature"
+	}
+}

--- a/src/Verlite.CLI/Verlite.CLI.csproj
+++ b/src/Verlite.CLI/Verlite.CLI.csproj
@@ -12,7 +12,7 @@
   <PropertyGroup Condition="'$(PublishAot)'=='true'">
     <TargetName>verlite</TargetName>
     <TargetExtension>elf</TargetExtension>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <SelfContained>true</SelfContained>
     <TrimMode>Link</TrimMode>
     <RootAllApplicationAssemblies>false</RootAllApplicationAssemblies>

--- a/src/Verlite.Core/PublicAPI.Unshipped.txt
+++ b/src/Verlite.Core/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+static Verlite.SemVer.CompareMetadata(string? left, string? right) -> int
+static Verlite.SemVer.ComparePrerelease(string? left, string? right) -> int

--- a/tests/IntegrationTests/tests/arg-escaping/src/TestEscaping/TestEscaping.csproj
+++ b/tests/IntegrationTests/tests/arg-escaping/src/TestEscaping/TestEscaping.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>

--- a/tests/UnitTests/PrecedenceTests.cs
+++ b/tests/UnitTests/PrecedenceTests.cs
@@ -46,5 +46,28 @@ namespace UnitTests
 			new SemVer(1, 0, 0, "alpha.101").Should().BeLessThan(new SemVer(1, 0, 0, "alpha.102"));
 			new SemVer(1, 0, 0, "alpha.aaa").Should().BeLessThan(new SemVer(1, 0, 0, "alpha.aab"));
 		}
+
+		[Fact]
+		public void OrderedMetaversions()
+		{
+			new SemVer(1, 0, 2, null, "abc").Should().BeGreaterThan(new SemVer(1, 0, 1));
+			new SemVer(1, 0, 0, null, "abc").Should().BeGreaterThan(new SemVer(1, 0, 0));
+			new SemVer(1, 0, 0, null, "abc").Should().BeGreaterThan(new SemVer(1, 0, 0));
+			new SemVer(1, 0, 1, null, "abc").Should().BeGreaterThan(new SemVer(1, 0, 0));
+			new SemVer(1, 0, 0, null, "abc").Should().BeLessThan(new SemVer(1, 0, 0, null, "alpha.0"));
+			new SemVer(1, 0, 0, null, "abc").Should().BeLessThan(new SemVer(1, 0, 0, null, "alpha.1"));
+			new SemVer(1, 0, 0, null, "abc.1").Should().BeLessThan(new SemVer(1, 0, 0, null, "alpha.2"));
+			new SemVer(1, 0, 0, null, "abc.2").Should().BeLessThan(new SemVer(1, 0, 0, null, "alpha.10"));
+			new SemVer(1, 0, 0, null, "abc.2.1").Should().BeLessThan(new SemVer(1, 0, 0, null, "alpha.100"));
+			new SemVer(1, 0, 0, null, "abc.101").Should().BeLessThan(new SemVer(1, 0, 0, null, "alpha.102"));
+			new SemVer(1, 0, 0, null, "abc.aaa").Should().BeLessThan(new SemVer(1, 0, 0, null, "alpha.aab"));
+
+			new SemVer(1, 0, 0, null, "abc").Should().BeGreaterThan(new SemVer(1, 0, 0, "def"));
+			new SemVer(1, 0, 0, "def", "abc").Should().BeGreaterThan(new SemVer(1, 0, 0, "def"));
+			new SemVer(1, 0, 0, "def", "abc").Should().BeGreaterThan(new SemVer(1, 0, 0, "def"));
+			new SemVer(1, 0, 0, "def", "b").Should().BeGreaterThan(new SemVer(1, 0, 0, "def", "a"));
+			new SemVer(1, 0, 0, "def", "rev.13").Should().BeGreaterThan(new SemVer(1, 0, 0, "def", "rev.1"));
+			new SemVer(1, 0, 0, "def", "aa").Should().BeGreaterThan(new SemVer(1, 0, 0, "def", "a"));
+		}
 	}
 }

--- a/tests/UnitTests/UnitTests.csproj
+++ b/tests/UnitTests/UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <!-- CA1014: Unit tests don't need to express thier CLS complience -->
     <!-- CS1591: Unit tests don't need xmldoc comments. -->

--- a/tests/UnitTests/VersionTests.cs
+++ b/tests/UnitTests/VersionTests.cs
@@ -88,13 +88,6 @@ namespace UnitTests
 		}
 
 		[Fact]
-		public void CompreableBuildInfoIgnored()
-		{
-			(new SemVer(1, 0, 0, "alpha.1", "abc").CompareTo(new SemVer(1, 0, 0, "alpha.1", "def"))).Should().Be(0);
-			(new SemVer(1, 0, 0, "alpha.1", "abc").CompareTo(new SemVer(1, 0, 0, "alpha.2", "def"))).Should().Be(-1);
-		}
-
-		[Fact]
 		public void CoreVersionFunctions()
 		{
 			new SemVer(1, 0, 0, "alpha.1", "abc").CoreVersion.Should().Be(new SemVer(1, 0, 0));


### PR DESCRIPTION
<!-- Please read CONTRIBUTING.md -->

This means the following order takes precedence:

- 1.0.0-alpha
- 1.0.0-alpha+post
- 1.0.0
- 1.0.0+post

- [x] Tests added
- [ ] Linked issue if exists
- [ ] Updated documentation
