### PR TITLE
Fixed min versions not working correctly with post releases

### DIFF
--- a/tests/UnitTests/VersionTests.cs
+++ b/tests/UnitTests/VersionTests.cs
@@ -96,6 +96,42 @@ namespace UnitTests
 		}
 
 		[Fact]
+		public void CoreVersionFunctionsWithPostTag()
+		{
+			var opts = new VersionCalculationOptions()
+			{
+				MinimumVersion = SemVer.Parse("1.0.0+rev.12"),
+			};
+			var directTag = SemVer.Parse("1.0.0+rev.500");
+			var version = VersionCalculator.FromTagInfomation(directTag, opts, 0);
+			version.Should().Be(directTag);
+		}
+
+		[Fact]
+		public void PrereleaseVersionFunctionsWithPostTag()
+		{
+			var opts = new VersionCalculationOptions()
+			{
+				MinimumVersion = SemVer.Parse("1.0.0-rc.2+rev.12"),
+			};
+			var directTag = SemVer.Parse("1.0.0-rc.2+rev.500");
+			var version = VersionCalculator.FromTagInfomation(directTag, opts, 0);
+			version.Should().Be(directTag);
+		}
+
+		[Fact]
+		public void InvalidPrereleaseVersionThrowsWithPostTag()
+		{
+			var opts = new VersionCalculationOptions()
+			{
+				MinimumVersion = SemVer.Parse("1.0.0-rc.2+rev.12"),
+			};
+
+			Assert.Throws<VersionCalculationException>(() => VersionCalculator.FromTagInfomation(SemVer.Parse("1.0.0-rc.1+rev.501"), opts, 0));
+			Assert.Throws<VersionCalculationException>(() => VersionCalculator.FromTagInfomation(SemVer.Parse("1.0.0-rc.2+rev.1"), opts, 0));
+		}
+
+		[Fact]
 		[Obsolete("Function tested is obsolete.")]
 		public void DestinedVersionFunctions()
 		{


### PR DESCRIPTION
…

The minimum version was not correctly factoring in the post releases by chopping off the meta field when taking the core version. Now, a promotion to core version is only allowed when: the min ver prerelease is not set; and the core version is greater than the tag version.

In addition to this fix, prereleases are now correctly checked when a minimum version contains a prerelease.

<!-- Please read CONTRIBUTING.md -->

High level of what was changed, possibly include why this approach was taken.

Are there any concerns or areas to be aware of regarding the approach taken or areas changed?

- [x] Tests added
- [ ] Linked issue if exists
- [ ] Updated documentation
